### PR TITLE
roc-core: fix define statement

### DIFF
--- a/src/modules/roc_core/target_posix/roc_core/endian.h
+++ b/src/modules/roc_core/target_posix/roc_core/endian.h
@@ -19,15 +19,15 @@
 #include <sys/types.h>
 
 //! Network to host (16 bits).
-#define ROC_NTOH_16(v) ntohs(uint16_t(v))
+#define ROC_NTOH_16(v) ntohs(((uint16_t)(v)))
 
 //! Network to host (32 bits).
-#define ROC_NTOH_32(v) ntohl(uint32_t(v))
+#define ROC_NTOH_32(v) ntohl(((uint32_t)(v)))
 
 //! Host to network (16 bits).
-#define ROC_HTON_16(v) htons(uint16_t(v))
+#define ROC_HTON_16(v) htons(((uint16_t)(v)))
 
 //! Host to network (32 bits).
-#define ROC_HTON_32(v) htonl(uint32_t(v))
+#define ROC_HTON_32(v) htonl(((uint32_t)(v)))
 
 #endif // ROC_CORE_ENDIAN_H_


### PR DESCRIPTION
Due to:

```
In file included from src/modules/roc_rtp/format_map.cpp:11:
In file included from src/modules/roc_rtp/pcm_decoder.h:18:
src/modules/roc_rtp/pcm_helpers.h:47:21: error: cannot take the address of an rvalue of type 'int'
    return (int16_t)ROC_HTON_16(uint16_t(hs));
                    ^~~~~~~~~~~~~~~~~~~~~~~~~
src/modules/roc_core/target_posix/roc_core/endian.h:28:24: note: expanded from macro 'ROC_HTON_16'
#define ROC_HTON_16(v) htons(uint16_t(v))
                       ^~~~~~~~~~~~~~~~~~
/usr/include/sys/_endian.h:133:18: note: expanded from macro 'htons'
#define htons(x)        __DARWIN_OSSwapInt16(x)
                        ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libkern/_OSByteOrder.h:72:45: note: expanded from macro '__DARWIN_OSSwapInt16'
    ((__uint16_t)(__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt16(x) : _OSSwapInt16(x)))
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libkern/_OSByteOrder.h:44:37: note: expanded from macro '__DARWIN_OSSwapConstInt16'
    ((__uint16_t)((((__uint16_t)(x) & 0xff00) >> 8) | \
                                    ^ ~~~~~~
In file included from src/modules/roc_rtp/format_map.cpp:11:
In file included from src/modules/roc_rtp/pcm_decoder.h:18:
src/modules/roc_rtp/pcm_helpers.h:47:21: error: cannot take the address of an rvalue of type 'int'
    return (int16_t)ROC_HTON_16(uint16_t(hs));
                    ^~~~~~~~~~~~~~~~~~~~~~~~~
src/modules/roc_core/target_posix/roc_core/endian.h:28:24: note: expanded from macro 'ROC_HTON_16'
#define ROC_HTON_16(v) htons(uint16_t(v))
                       ^~~~~~~~~~~~~~~~~~
/usr/include/sys/_endian.h:133:18: note: expanded from macro 'htons'
#define htons(x)        __DARWIN_OSSwapInt16(x)
                        ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libkern/_OSByteOrder.h:72:45: note: expanded from macro '__DARWIN_OSSwapInt16'
    ((__uint16_t)(__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt16(x) : _OSSwapInt16(x)))
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libkern/_OSByteOrder.h:45:35: note: expanded from macro '__DARWIN_OSSwapConstInt16'
                (((__uint16_t)(x) & 0x00ff) << 8)))
                                  ^ ~~~~~~
In file included from src/modules/roc_rtp/format_map.cpp:11:
In file included from src/modules/roc_rtp/pcm_decoder.h:18:
src/modules/roc_rtp/pcm_helpers.h:52:33: error: cannot take the address of an rvalue of type 'int'
    const int16_t hs = (int16_t)ROC_NTOH_16(uint16_t(ns));
                                ^~~~~~~~~~~~~~~~~~~~~~~~~
src/modules/roc_core/target_posix/roc_core/endian.h:22:24: note: expanded from macro 'ROC_NTOH_16'
#define ROC_NTOH_16(v) ntohs(uint16_t(v))
                       ^~~~~~~~~~~~~~~~~~
/usr/include/sys/_endian.h:132:18: note: expanded from macro 'ntohs'
#define ntohs(x)        __DARWIN_OSSwapInt16(x)
                        ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libkern/_OSByteOrder.h:72:45: note: expanded from macro '__DARWIN_OSSwapInt16'
    ((__uint16_t)(__builtin_constant_p(x) ? __DARWIN_OSSwapConstInt16(x) : _OSSwapInt16(x)))
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libkern/_OSByteOrder.h:44:37: note: expanded from macro '__DARWIN_OSSwapConstInt16'
    ((__uint16_t)((((__uint16_t)(x) & 0xff00) >> 8) | \
                                    ^ ~~~~~~
In file included from src/modules/roc_rtp/format_map.cpp:11:
In file included from src/modules/roc_rtp/pcm_decoder.h:18:
src/modules/roc_rtp/pcm_helpers.h:52:33: error: cannot take the address of an rvalue of type 'int'
    const int16_t hs = (int16_t)ROC_NTOH_16(uint16_t(ns));
                                ^~~~~~~~~~~~~~~~~~~~~~~~~
src/modules/roc_core/target_posix/roc_core/endian.h:22:24: note: expanded from macro 'ROC_NTOH_16'
#define ROC_NTOH_16(v) ntohs(uint16_t(v))
                       ^~~~~~~~~~~~~~~~~~
/usr/include/sys/_endian.h:132:18: note: expanded from macro 'ntohs'
#define ntohs(x)        __DARWIN_OSSwapInt16(x)
                        ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/libkern/_OSByteOrder.
```