### PR TITLE
travis: use ruby 2.4.0 for osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,6 @@ matrix:
         - cat build.status
 
     - os: osx
-      osx_image: xcode7.3
-      script:
-        - scripts/travis/osx/build.sh
-
-    - os: osx
       osx_image: xcode9.1
       script:
         - scripts/travis/osx/build.sh

--- a/scripts/travis/osx/build.sh
+++ b/scripts/travis/osx/build.sh
@@ -1,6 +1,9 @@
 #! /bin/bash
 set -xe
 
+ruby -v
+rvm get stable --auto-dotfiles
+
 brew tap Homebrew/bundle
 brew bundle --file=scripts/travis/osx/Brewfile
 


### PR DESCRIPTION
This PR fixes a Travis build for OS X.