### PR TITLE
roc-recv: override sample rate when resampling is disabled

### DIFF
--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -117,6 +117,10 @@ int main(int argc, char** argv) {
             return 1;
         }
         sample_rate = (size_t)args.rate_arg;
+    } else {
+        if (!config.default_session.resampling) {
+            sample_rate = pipeline::DefaultSampleRate;
+        }
     }
 
     if (args.timeout_given) {


### PR DESCRIPTION
Relates: #133