### PR TITLE
Implement frame poisoning

### DIFF
--- a/src/lib/src/config.cpp
+++ b/src/lib/src/config.cpp
@@ -114,7 +114,7 @@ bool config_receiver(pipeline::ReceiverConfig& out, const roc_receiver_config& i
     }
 
     if (in.sample_rate) {
-        out.sample_rate = in.sample_rate;
+        out.output.sample_rate = in.sample_rate;
     }
 
     switch ((unsigned)in.fec_scheme) {
@@ -137,8 +137,8 @@ bool config_receiver(pipeline::ReceiverConfig& out, const roc_receiver_config& i
         out.default_session.fec.n_repair_packets = in.n_repair_packets;
     }
 
-    out.default_session.resampling = !(in.flags & ROC_FLAG_DISABLE_RESAMPLER);
-    out.timing = (in.flags & ROC_FLAG_ENABLE_TIMER);
+    out.output.resampling = !(in.flags & ROC_FLAG_DISABLE_RESAMPLER);
+    out.output.timing = (in.flags & ROC_FLAG_ENABLE_TIMER);
 
     return true;
 }

--- a/src/lib/src/private.h
+++ b/src/lib/src/private.h
@@ -60,7 +60,11 @@ struct roc_sender {
     roc_context& context;
 
     roc::rtp::FormatMap format_map;
+
     roc::pipeline::SenderConfig config;
+
+    roc::pipeline::PortConfig source_port;
+    roc::pipeline::PortConfig repair_port;
 
     roc::core::UniquePtr<roc::pipeline::Sender> sender;
     roc::packet::IWriter* writer;

--- a/src/lib/src/receiver.cpp
+++ b/src/lib/src/receiver.cpp
@@ -33,7 +33,7 @@ roc_receiver::roc_receiver(roc_context& ctx, pipeline::ReceiverConfig& cfg)
                context.byte_buffer_pool,
                context.sample_buffer_pool,
                context.allocator)
-    , num_channels(packet::num_channels(cfg.channels)) {
+    , num_channels(packet::num_channels(cfg.output.channels)) {
 }
 
 roc_receiver* roc_receiver_open(roc_context* context, const roc_receiver_config* config) {

--- a/src/modules/roc_audio/poison_reader.cpp
+++ b/src/modules/roc_audio/poison_reader.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_audio/poison_reader.h"
+#include "roc_audio/units.h"
+
+namespace roc {
+namespace audio {
+
+PoisonReader::PoisonReader(IReader& reader)
+    : reader_(reader) {
+}
+
+void PoisonReader::read(Frame& frame) {
+    const size_t frame_size = frame.size();
+    sample_t* frame_data = frame.data();
+
+    for (size_t n = 0; n < frame_size; n++) {
+        frame_data[n] = SampleMax;
+    }
+
+    reader_.read(frame);
+}
+
+} // namespace audio
+} // namespace roc

--- a/src/modules/roc_audio/poison_reader.h
+++ b/src/modules/roc_audio/poison_reader.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_audio/poison_reader.h
+//! @brief Poison reader.
+
+#ifndef ROC_AUDIO_POISON_READER_H_
+#define ROC_AUDIO_POISON_READER_H_
+
+#include "roc_audio/frame.h"
+#include "roc_audio/ireader.h"
+#include "roc_core/noncopyable.h"
+
+namespace roc {
+namespace audio {
+
+//! Poisons audio frames before reading them.
+class PoisonReader : public IReader, public core::NonCopyable<> {
+public:
+    //! Initialize.
+    PoisonReader(IReader& reader);
+
+    //! Read audio frame.
+    virtual void read(Frame&);
+
+private:
+    IReader& reader_;
+};
+
+} // namespace audio
+} // namespace roc
+
+#endif // ROC_AUDIO_POISON_READER_H_

--- a/src/modules/roc_audio/poison_writer.cpp
+++ b/src/modules/roc_audio/poison_writer.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_audio/poison_writer.h"
+#include "roc_audio/units.h"
+
+namespace roc {
+namespace audio {
+
+PoisonWriter::PoisonWriter(IWriter& writer)
+    : writer_(writer) {
+}
+
+void PoisonWriter::write(Frame& frame) {
+    writer_.write(frame);
+
+    const size_t frame_size = frame.size();
+    sample_t* frame_data = frame.data();
+
+    for (size_t n = 0; n < frame_size; n++) {
+        frame_data[n] = SampleMax;
+    }
+}
+
+} // namespace audio
+} // namespace roc

--- a/src/modules/roc_audio/poison_writer.h
+++ b/src/modules/roc_audio/poison_writer.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_audio/poison_writer.h
+//! @brief Poison writer.
+
+#ifndef ROC_AUDIO_POISON_WRITER_H_
+#define ROC_AUDIO_POISON_WRITER_H_
+
+#include "roc_audio/frame.h"
+#include "roc_audio/iwriter.h"
+#include "roc_core/noncopyable.h"
+
+namespace roc {
+namespace audio {
+
+//! Poisons audio frames after writing them.
+class PoisonWriter : public IWriter, public core::NonCopyable<> {
+public:
+    //! Initialize.
+    PoisonWriter(IWriter& writer);
+
+    //! Write audio frame.
+    virtual void write(Frame&);
+
+private:
+    IWriter& writer_;
+};
+
+} // namespace audio
+} // namespace roc
+
+#endif // ROC_AUDIO_POISON_WRITER_H_

--- a/src/modules/roc_pipeline/config.h
+++ b/src/modules/roc_pipeline/config.h
@@ -141,10 +141,14 @@ struct ReceiverConfig {
     //! Constrain receiver speed using a CPU timer according to the sample rate.
     bool timing;
 
+    //! Fill uninitialized data with large values to make them more noticeable.
+    bool poisoning;
+
     ReceiverConfig()
         : sample_rate(DefaultSampleRate)
         , channels(DefaultChannelMask)
-        , timing(false) {
+        , timing(false)
+        , poisoning(false) {
     }
 };
 
@@ -183,6 +187,9 @@ struct SenderConfig {
     //! Constrain receiver speed using a CPU timer according to the sample rate.
     bool timing;
 
+    //! Fill unitialized data with large values to make them more noticable.
+    bool poisoning;
+
     SenderConfig()
         : sample_rate(DefaultSampleRate)
         , channels(DefaultChannelMask)
@@ -190,7 +197,8 @@ struct SenderConfig {
         , samples_per_packet(DefaultPacketSize)
         , resampling(false)
         , interleaving(false)
-        , timing(false) {
+        , timing(false)
+        , poisoning(false) {
     }
 };
 

--- a/src/modules/roc_pipeline/config.h
+++ b/src/modules/roc_pipeline/config.h
@@ -79,10 +79,10 @@ struct PortConfig {
     }
 };
 
-//! Session parameters.
+//! Receiver session parameters.
 //! @remarks
 //!  Defines per-session parameters on the receiver side.
-struct SessionConfig {
+struct ReceiverSessionConfig {
     //! Channel mask.
     packet::channel_mask_t channels;
 
@@ -107,19 +107,11 @@ struct SessionConfig {
     //! Resampler parameters.
     audio::ResamplerConfig resampler;
 
-    //! Perform resampling to to compensate sender and receiver frequency difference.
-    bool resampling;
-
-    //! Insert weird beeps instead of silence on packet loss.
-    bool beeping;
-
-    SessionConfig()
+    ReceiverSessionConfig()
         : channels(DefaultChannelMask)
         , samples_per_packet(DefaultPacketSize)
         , latency(DefaultPacketSize * 27)
-        , watchdog(DefaultSampleRate)
-        , resampling(false)
-        , beeping(false) {
+        , watchdog(DefaultSampleRate) {
         latency_monitor.min_latency =
             (packet::signed_timestamp_t)latency * DefaultMinLatency;
         latency_monitor.max_latency =
@@ -127,16 +119,18 @@ struct SessionConfig {
     }
 };
 
-//! Receiver parameters.
-struct ReceiverConfig {
-    //! Default parameters for session.
-    SessionConfig default_session;
-
+//! Receiver output parameters.
+//! @remarks
+//!  Defines common output parameters on the receiver side.
+struct ReceiverOutputConfig {
     //! Number of samples per second per channel.
     size_t sample_rate;
 
     //! Channel mask.
     packet::channel_mask_t channels;
+
+    //! Perform resampling to compensate sender and receiver frequency difference.
+    bool resampling;
 
     //! Constrain receiver speed using a CPU timer according to the sample rate.
     bool timing;
@@ -144,22 +138,30 @@ struct ReceiverConfig {
     //! Fill uninitialized data with large values to make them more noticeable.
     bool poisoning;
 
-    ReceiverConfig()
+    //! Insert weird beeps instead of silence on packet loss.
+    bool beeping;
+
+    ReceiverOutputConfig()
         : sample_rate(DefaultSampleRate)
         , channels(DefaultChannelMask)
+        , resampling(false)
         , timing(false)
-        , poisoning(false) {
+        , poisoning(false)
+        , beeping(false) {
     }
+};
+
+//! Receiver parameters.
+struct ReceiverConfig {
+    //! Default parameters for receiver session.
+    ReceiverSessionConfig default_session;
+
+    //! Parameters for receiver output.
+    ReceiverOutputConfig output;
 };
 
 //! Sender parameters.
 struct SenderConfig {
-    //! Parameters for the port to which source packets are sent.
-    PortConfig source_port;
-
-    //! Parameters for the port to which repair packets are sent.
-    PortConfig repair_port;
-
     //! Resampler parameters.
     audio::ResamplerConfig resampler;
 

--- a/src/modules/roc_pipeline/receiver.h
+++ b/src/modules/roc_pipeline/receiver.h
@@ -14,6 +14,7 @@
 
 #include "roc_audio/ireader.h"
 #include "roc_audio/mixer.h"
+#include "roc_audio/poison_reader.h"
 #include "roc_core/buffer_pool.h"
 #include "roc_core/cond.h"
 #include "roc_core/iallocator.h"
@@ -95,15 +96,17 @@ private:
 
     core::List<packet::Packet> packets_;
 
-    audio::Mixer mixer_;
     core::Ticker ticker_;
+
+    core::UniquePtr<audio::Mixer> mixer_;
+    core::UniquePtr<audio::PoisonReader> poisoner_;
+
+    audio::IReader* audio_reader_;
 
     ReceiverConfig config_;
 
     packet::timestamp_t timestamp_;
     size_t num_channels_;
-
-    bool valid_;
 
     core::Mutex control_mutex_;
     core::Mutex pipeline_mutex_;

--- a/src/modules/roc_pipeline/receiver_session.h
+++ b/src/modules/roc_pipeline/receiver_session.h
@@ -48,10 +48,9 @@ namespace pipeline {
 class ReceiverSession : public core::RefCnt<ReceiverSession>, public core::ListNode {
 public:
     //! Initialize.
-    ReceiverSession(const SessionConfig& config,
+    ReceiverSession(const ReceiverSessionConfig& session_config,
+                    const ReceiverOutputConfig& output_config,
                     unsigned int payload_type,
-                    size_t out_sample_rate,
-                    bool poisoning,
                     const packet::Address& src_address,
                     const rtp::FormatMap& format_map,
                     packet::PacketPool& packet_pool,

--- a/src/modules/roc_pipeline/receiver_session.h
+++ b/src/modules/roc_pipeline/receiver_session.h
@@ -16,6 +16,7 @@
 #include "roc_audio/idecoder.h"
 #include "roc_audio/ireader.h"
 #include "roc_audio/latency_monitor.h"
+#include "roc_audio/poison_reader.h"
 #include "roc_audio/resampler_reader.h"
 #include "roc_audio/watchdog.h"
 #include "roc_core/buffer_pool.h"
@@ -50,6 +51,7 @@ public:
     ReceiverSession(const SessionConfig& config,
                     unsigned int payload_type,
                     size_t out_sample_rate,
+                    bool poisoning,
                     const packet::Address& src_address,
                     const rtp::FormatMap& format_map,
                     packet::PacketPool& packet_pool,
@@ -101,7 +103,10 @@ private:
     core::UniquePtr<audio::IDecoder> decoder_;
     core::UniquePtr<audio::Depacketizer> depacketizer_;
 
+    core::UniquePtr<audio::PoisonReader> resampler_poisoner_;
     core::UniquePtr<audio::ResamplerReader> resampler_;
+
+    core::UniquePtr<audio::PoisonReader> session_poisoner_;
 
     core::UniquePtr<audio::LatencyMonitor> latency_monitor_;
 };

--- a/src/modules/roc_pipeline/sender.cpp
+++ b/src/modules/roc_pipeline/sender.cpp
@@ -18,7 +18,9 @@ namespace roc {
 namespace pipeline {
 
 Sender::Sender(const SenderConfig& config,
+               const PortConfig& source_port_config,
                packet::IWriter& source_writer,
+               const PortConfig& repair_port_config,
                packet::IWriter& repair_writer,
                const rtp::FormatMap& format_map,
                packet::PacketPool& packet_pool,
@@ -40,17 +42,15 @@ Sender::Sender(const SenderConfig& config,
         }
     }
 
-    source_port_.reset(new (allocator)
-                           SenderPort(config.source_port, source_writer, allocator),
+    source_port_.reset(new (allocator) SenderPort(source_port_config, source_writer, allocator),
                        allocator);
     if (!source_port_ || !source_port_->valid()) {
         return;
     }
 
-    if (config.repair_port.protocol != Proto_None) {
-        repair_port_.reset(new (allocator)
-                               SenderPort(config.repair_port, repair_writer, allocator),
-                           allocator);
+    if (repair_port_config.protocol != Proto_None) {
+        repair_port_.reset(
+            new (allocator) SenderPort(repair_port_config, repair_writer, allocator), allocator);
         if (!repair_port_ || !repair_port_->valid()) {
             return;
         }

--- a/src/modules/roc_pipeline/sender.h
+++ b/src/modules/roc_pipeline/sender.h
@@ -15,6 +15,7 @@
 #include "roc_audio/iencoder.h"
 #include "roc_audio/iwriter.h"
 #include "roc_audio/packetizer.h"
+#include "roc_audio/poison_writer.h"
 #include "roc_audio/resampler_writer.h"
 #include "roc_core/buffer_pool.h"
 #include "roc_core/iallocator.h"
@@ -65,7 +66,11 @@ private:
 
     core::UniquePtr<audio::IEncoder> encoder_;
     core::UniquePtr<audio::Packetizer> packetizer_;
+
+    core::UniquePtr<audio::PoisonWriter> resampler_poisoner_;
     core::UniquePtr<audio::ResamplerWriter> resampler_;
+
+    core::UniquePtr<audio::PoisonWriter> pipeline_poisoner_;
 
     core::UniquePtr<core::Ticker> ticker_;
 

--- a/src/modules/roc_pipeline/sender.h
+++ b/src/modules/roc_pipeline/sender.h
@@ -39,7 +39,9 @@ class Sender : public audio::IWriter, public core::NonCopyable<> {
 public:
     //! Initialize.
     Sender(const SenderConfig& config,
+           const PortConfig& source_port,
            packet::IWriter& source_writer,
+           const PortConfig& repair_port,
            packet::IWriter& repair_writer,
            const rtp::FormatMap& format_map,
            packet::PacketPool& packet_pool,

--- a/src/tests/roc_pipeline/test_receiver.cpp
+++ b/src/tests/roc_pipeline/test_receiver.cpp
@@ -68,8 +68,8 @@ TEST_GROUP(receiver) {
     PortConfig port2;
 
     void setup() {
-        config.sample_rate = SampleRate;
-        config.channels = ChMask;
+        config.output.sample_rate = SampleRate;
+        config.output.channels = ChMask;
 
         config.default_session.channels = ChMask;
         config.default_session.samples_per_packet = SamplesPerPacket;

--- a/src/tests/roc_pipeline/test_sender.cpp
+++ b/src/tests/roc_pipeline/test_sender.cpp
@@ -55,9 +55,12 @@ rtp::PCMDecoder<int16_t, NumCh> pcm_decoder;
 TEST_GROUP(sender) {
     SenderConfig config;
 
+    PortConfig source_port;
+    PortConfig repair_port;
+
     void setup() {
-        config.source_port.address = new_address(1);
-        config.source_port.protocol = Proto_RTP;
+        source_port.address = new_address(1);
+        source_port.protocol = Proto_RTP;
 
         config.channels = ChMask;
         config.samples_per_packet = SamplesPerPacket;
@@ -70,8 +73,8 @@ TEST_GROUP(sender) {
 TEST(sender, write) {
     packet::Queue queue;
 
-    Sender sender(config, queue, queue, format_map, packet_pool, byte_buffer_pool,
-                  sample_buffer_pool, allocator);
+    Sender sender(config, source_port, queue, repair_port, queue, format_map, packet_pool,
+                  byte_buffer_pool, sample_buffer_pool, allocator);
 
     CHECK(sender.valid());
 
@@ -82,7 +85,7 @@ TEST(sender, write) {
     }
 
     PacketReader packet_reader(queue, rtp_parser, pcm_decoder, packet_pool, PayloadType,
-                               config.source_port.address);
+                               source_port.address);
 
     for (size_t np = 0; np < ManyFrames / FramesPerPacket; np++) {
         packet_reader.read_packet(SamplesPerPacket, ChMask);
@@ -100,8 +103,8 @@ TEST(sender, frame_size_small) {
 
     packet::Queue queue;
 
-    Sender sender(config, queue, queue, format_map, packet_pool, byte_buffer_pool,
-                  sample_buffer_pool, allocator);
+    Sender sender(config, source_port, queue, repair_port, queue, format_map, packet_pool,
+                  byte_buffer_pool, sample_buffer_pool, allocator);
 
     CHECK(sender.valid());
 
@@ -112,7 +115,7 @@ TEST(sender, frame_size_small) {
     }
 
     PacketReader packet_reader(queue, rtp_parser, pcm_decoder, packet_pool, PayloadType,
-                               config.source_port.address);
+                               source_port.address);
 
     for (size_t np = 0; np < ManySmallFrames / SmallFramesPerPacket; np++) {
         packet_reader.read_packet(SamplesPerPacket, ChMask);
@@ -130,8 +133,8 @@ TEST(sender, frame_size_large) {
 
     packet::Queue queue;
 
-    Sender sender(config, queue, queue, format_map, packet_pool, byte_buffer_pool,
-                  sample_buffer_pool, allocator);
+    Sender sender(config, source_port, queue, repair_port, queue, format_map, packet_pool,
+                  byte_buffer_pool, sample_buffer_pool, allocator);
 
     CHECK(sender.valid());
 
@@ -142,7 +145,7 @@ TEST(sender, frame_size_large) {
     }
 
     PacketReader packet_reader(queue, rtp_parser, pcm_decoder, packet_pool, PayloadType,
-                               config.source_port.address);
+                               source_port.address);
 
     for (size_t np = 0; np < ManyLargeFrames * PacketsPerLargeFrame; np++) {
         packet_reader.read_packet(SamplesPerPacket, ChMask);

--- a/src/tests/roc_pipeline/test_sender_receiver.cpp
+++ b/src/tests/roc_pipeline/test_sender_receiver.cpp
@@ -80,8 +80,10 @@ TEST_GROUP(sender_receiver) {
         PortConfig source_port = source_port_config(flags);
         PortConfig repair_port = repair_port_config(flags);
 
-        Sender sender(sender_config(flags, source_port, repair_port),
+        Sender sender(sender_config(flags),
+                      source_port,
                       queue,
+                      repair_port,
                       queue,
                       format_map,
                       packet_pool,
@@ -164,13 +166,8 @@ TEST_GROUP(sender_receiver) {
         return port;
     }
 
-    SenderConfig sender_config(int flags,
-                               const PortConfig& source_port,
-                               const PortConfig& repair_port) {
+    SenderConfig sender_config(int flags) {
         SenderConfig config;
-
-        config.source_port = source_port;
-        config.repair_port = repair_port;
 
         config.channels = ChMask;
         config.samples_per_packet = SamplesPerPacket;
@@ -186,8 +183,8 @@ TEST_GROUP(sender_receiver) {
     ReceiverConfig receiver_config(int flags) {
         ReceiverConfig config;
 
-        config.sample_rate = SampleRate;
-        config.channels = ChMask;
+        config.output.sample_rate = SampleRate;
+        config.output.channels = ChMask;
 
         config.default_session.channels = ChMask;
         config.default_session.samples_per_packet = SamplesPerPacket;

--- a/src/tools/roc_conv/cmdline.ggo
+++ b/src/tools/roc_conv/cmdline.ggo
@@ -25,3 +25,6 @@ section "Options"
 
     option "resampler-frame" - "Number of samples per resampler frame"
         int optional
+
+    option "poisoning" - "Enable uninitialized memory poisoning"
+        flag off

--- a/src/tools/roc_recv/cmdline.ggo
+++ b/src/tools/roc_recv/cmdline.ggo
@@ -56,6 +56,9 @@ section "Options"
     option "oneshot" 1 "Exit when last connected client disconnects"
         flag off
 
+    option "poisoning" - "Enable uninitialized memory poisoning"
+        flag off
+
     option "beeping" - "Enable beeping on packet loss" flag off
 
 text "

--- a/src/tools/roc_recv/cmdline.ggo
+++ b/src/tools/roc_recv/cmdline.ggo
@@ -56,7 +56,7 @@ section "Options"
     option "oneshot" 1 "Exit when last connected client disconnects"
         flag off
 
-    option "beep" - "Enable beep on packet loss" flag off
+    option "beeping" - "Enable beeping on packet loss" flag off
 
 text "
 ADDRESS should be in one of the following forms:

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
 
     pipeline::ReceiverConfig config;
 
-    config.poisoning = args.poisoning_flag;
+    config.output.poisoning = args.poisoning_flag;
 
     switch ((unsigned)args.fec_arg) {
     case fec_arg_none:
@@ -110,8 +110,8 @@ int main(int argc, char** argv) {
         config.default_session.fec.n_repair_packets = (size_t)args.nbrpr_arg;
     }
 
-    config.default_session.resampling = !args.no_resampling_flag;
-    config.default_session.beeping = args.beeping_flag;
+    config.output.resampling = !args.no_resampling_flag;
+    config.output.beeping = args.beeping_flag;
 
     size_t sample_rate = 0;
     if (args.rate_given) {
@@ -121,7 +121,7 @@ int main(int argc, char** argv) {
         }
         sample_rate = (size_t)args.rate_arg;
     } else {
-        if (!config.default_session.resampling) {
+        if (!config.output.resampling) {
             sample_rate = pipeline::DefaultSampleRate;
         }
     }
@@ -218,7 +218,7 @@ int main(int argc, char** argv) {
     core::BufferPool<audio::sample_t> sample_buffer_pool(allocator, MaxFrameSize, 1);
     packet::PacketPool packet_pool(allocator, 1);
 
-    sndio::SoxWriter writer(allocator, config.channels, sample_rate);
+    sndio::SoxWriter writer(allocator, config.output.channels, sample_rate);
 
     if (!writer.open(args.output_arg, args.type_arg)) {
         roc_log(LogError, "can't open output file or device: %s %s", args.output_arg,
@@ -226,10 +226,10 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    config.timing = writer.is_file();
-    config.sample_rate = writer.sample_rate();
+    config.output.timing = writer.is_file();
+    config.output.sample_rate = writer.sample_rate();
 
-    if (config.sample_rate == 0) {
+    if (config.output.sample_rate == 0) {
         roc_log(LogError, "can't detect output sample rate, try to set it "
                           "explicitly with --rate option");
         return 1;

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -61,6 +61,8 @@ int main(int argc, char** argv) {
 
     pipeline::ReceiverConfig config;
 
+    config.poisoning = args.poisoning_flag;
+
     switch ((unsigned)args.fec_arg) {
     case fec_arg_none:
         config.default_session.fec.codec = fec::NoCodec;

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
     }
 
     config.default_session.resampling = !args.no_resampling_flag;
-    config.default_session.beeping = args.beep_flag;
+    config.default_session.beeping = args.beeping_flag;
 
     size_t sample_rate = 0;
     if (args.rate_given) {

--- a/src/tools/roc_send/cmdline.ggo
+++ b/src/tools/roc_send/cmdline.ggo
@@ -38,6 +38,9 @@ section "Options"
 
     option "interleaving" - "Enable packet interleaving" flag off
 
+    option "poisoning" - "Enable uninitialized memory poisoning"
+        flag off
+
 text "
 ADDRESS should be in one of the following forms:
   - :PORT

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -116,6 +116,7 @@ int main(int argc, char** argv) {
 
     config.interleaving = args.interleaving_flag;
     config.resampling = !args.no_resampling_flag;
+    config.poisoning = args.poisoning_flag;
 
     if (args.resampler_interp_given) {
         if (args.resampler_interp_arg <= 0) {


### PR DESCRIPTION
This PR adds the --poisoning flag. When enabled, every component that creates new frames begins to "poison" them (just fill with ones) before passing further to the pipeline. This simple technique helps to detect components that leaves some frame samples uninitialized, because now these samples become more audible.

@dshil could you please review this?