### PR TITLE
tools: avoid memory leaks

### DIFF
--- a/src/modules/roc_core/target_posix/roc_core/scoped_destructor.h
+++ b/src/modules/roc_core/target_posix/roc_core/scoped_destructor.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_core/target_posix/roc_core/scoped_destructor.h
+//! @brief Scoped destructor.
+
+#ifndef ROC_CORE_SCOPED_DESTRUCTOR_H_
+#define ROC_CORE_SCOPED_DESTRUCTOR_H_
+
+#include "roc_core/stddefs.h"
+#include "roc_core/noncopyable.h"
+
+namespace roc {
+namespace core {
+
+//! Destroys the object via custom deleter.
+template <class T, void (*Func)(T)>
+class ScopedDestructor : public core::NonCopyable<> {
+public:
+    //! Initialize.
+    ScopedDestructor(T obj)
+        : obj_(obj) {
+    }
+
+    //! Destroy.
+    ~ScopedDestructor() {
+        Func(obj_);
+    }
+
+private:
+    T obj_;
+};
+
+} // namespace core
+} // namespace roc
+
+#endif // ROC_CORE_SCOPED_DESTRUCTOR_H_

--- a/src/tools/roc_conv/main.cpp
+++ b/src/tools/roc_conv/main.cpp
@@ -15,6 +15,7 @@
 #include "roc_core/crash.h"
 #include "roc_core/heap_allocator.h"
 #include "roc_core/log.h"
+#include "roc_core/scoped_destructor.h"
 #include "roc_sndio/sox.h"
 #include "roc_sndio/sox_reader.h"
 #include "roc_sndio/sox_writer.h"
@@ -38,6 +39,9 @@ int main(int argc, char** argv) {
     if (code != 0) {
         return code;
     }
+
+    core::ScopedDestructor<gengetopt_args_info*, cmdline_parser_free>
+        args_destructor(&args);
 
     core::Logger::instance().set_level(
         LogLevel(core::DefaultLogLevel + args.verbose_given));

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -9,6 +9,7 @@
 #include "roc_core/crash.h"
 #include "roc_core/heap_allocator.h"
 #include "roc_core/log.h"
+#include "roc_core/scoped_destructor.h"
 #include "roc_netio/transceiver.h"
 #include "roc_packet/address_to_str.h"
 #include "roc_packet/parse_address.h"
@@ -36,6 +37,9 @@ int main(int argc, char** argv) {
     if (code != 0) {
         return code;
     }
+
+    core::ScopedDestructor<gengetopt_args_info*, cmdline_parser_free>
+        args_destructor(&args);
 
     core::Logger::instance().set_level(
         LogLevel(core::DefaultLogLevel + args.verbose_given));

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -9,6 +9,7 @@
 #include "roc_core/crash.h"
 #include "roc_core/heap_allocator.h"
 #include "roc_core/log.h"
+#include "roc_core/scoped_destructor.h"
 #include "roc_netio/transceiver.h"
 #include "roc_packet/address_to_str.h"
 #include "roc_packet/parse_address.h"
@@ -35,6 +36,9 @@ int main(int argc, char** argv) {
     if (code != 0) {
         return code;
     }
+
+    core::ScopedDestructor<gengetopt_args_info*, cmdline_parser_free>
+        args_destructor(&args);
 
     core::Logger::instance().set_level(
         LogLevel(core::DefaultLogLevel + args.verbose_given));


### PR DESCRIPTION
According to [1] we should release resources allocated during the
parsing process.

1. https://www.gnu.org/software/gengetopt/gengetopt.html

Relates: #90