### PR TITLE
roc_fec: handle source block number properly

### DIFF
--- a/src/modules/roc_fec/composer.h
+++ b/src/modules/roc_fec/composer.h
@@ -159,13 +159,13 @@ public:
         PayloadID& payload_id = *(PayloadID*)fec.payload_id.data();
 
         payload_id.clear();
-        payload_id.set_sbn(fec.blknum);
+        payload_id.set_sbn(fec.source_block_number);
 
         roc_panic_if(fec.source_block_length >= (uint16_t)-1);
         payload_id.set_k((uint16_t)fec.source_block_length);
 
-        roc_panic_if(fec.repair_symbol_id >= (uint16_t)-1);
-        payload_id.set_esi((uint16_t)fec.repair_symbol_id);
+        roc_panic_if(fec.encoding_symbol_id >= (uint16_t)-1);
+        payload_id.set_esi((uint16_t)fec.encoding_symbol_id);
 
         if (inner_composer_) {
             return inner_composer_->compose(packet);

--- a/src/modules/roc_fec/parser.h
+++ b/src/modules/roc_fec/parser.h
@@ -56,9 +56,9 @@ public:
 
         packet::FEC& fec = *packet.fec();
 
-        fec.blknum = (packet::seqnum_t)payload_id->sbn();
+        fec.source_block_number = (packet::blknum_t)payload_id->sbn();
         fec.source_block_length = payload_id->k();
-        fec.repair_symbol_id = payload_id->esi();
+        fec.encoding_symbol_id = payload_id->esi();
 
         if (Pos == Header) {
             fec.payload = buffer.range(sizeof(PayloadID), buffer.size());

--- a/src/modules/roc_fec/reader.h
+++ b/src/modules/roc_fec/reader.h
@@ -67,7 +67,7 @@ private:
 
     void next_block_();
     void try_repair_();
-    bool check_packet_(const packet::PacketPtr&, size_t pos);
+    bool check_packet_(const packet::PacketPtr&);
 
     void fetch_packets_();
     void update_packets_();
@@ -75,9 +75,7 @@ private:
     void update_source_packets_();
     void update_repair_packets_();
 
-    // drops outdated packets from the repair_queue_ until meets packets from the
-    // current block or later
-    void skip_repair_packets_();
+    void drop_repair_packets_from_prev_blocks_();
 
     IDecoder& decoder_;
 
@@ -99,7 +97,7 @@ private:
     bool can_repair_;
 
     size_t next_packet_;
-    packet::seqnum_t cur_block_sn_;
+    packet::blknum_t cur_sbn_;
 
     bool has_source_;
     packet::source_t source_;

--- a/src/modules/roc_fec/writer.h
+++ b/src/modules/roc_fec/writer.h
@@ -65,8 +65,11 @@ private:
     const size_t n_repair_packets_;
     const size_t payload_size_;
 
+    void handle_next_block_();
     packet::PacketPtr make_repair_packet_(packet::seqnum_t n);
-    void fill_packet_fec_id_(const packet::PacketPtr& packet, packet::seqnum_t n);
+    void fill_packet_fec_fields_(const packet::PacketPtr& packet, packet::seqnum_t n);
+    void fill_packet_rtp_fields_(const packet::PacketPtr& packet,
+                                 packet::seqnum_t sn, bool marker);
 
     IEncoder& encoder_;
     packet::IWriter& writer_;
@@ -82,7 +85,7 @@ private:
     packet::source_t source_;
     bool first_packet_;
 
-    packet::seqnum_t cur_block_source_sn_;
+    packet::blknum_t cur_sbn_;
     packet::seqnum_t cur_block_repair_sn_;
 
     size_t cur_packet_;

--- a/src/modules/roc_packet/fec.cpp
+++ b/src/modules/roc_packet/fec.cpp
@@ -13,9 +13,9 @@ namespace roc {
 namespace packet {
 
 FEC::FEC()
-    : blknum(0)
+    : source_block_number(0)
     , source_block_length(0)
-    , repair_symbol_id(0) {
+    , encoding_symbol_id(0) {
 }
 
 int FEC::compare(const FEC& other) const {

--- a/src/modules/roc_packet/fec.h
+++ b/src/modules/roc_packet/fec.h
@@ -21,16 +21,28 @@ namespace packet {
 
 //! FECFRAME packet.
 struct FEC {
-    //! Seqnum of first source packet in block.
-    seqnum_t blknum;
+    //! Number of a source block in a packet stream.
+    //!
+    //! @remarks
+    //!  Source block is formed from the source packets.
+    //!  Blocks are numbered sequentially starting from a random number.
+    //!  Block number can wrap.
+    blknum_t source_block_number;
 
-    //! The number of source packet per block.
+    //! Number of source packets in the block to which this packet belongs to.
+    //!
+    //! @remarks
+    //!  Different blocks can have different number of source packets.
     size_t source_block_length;
 
-    //! The index number of the repair packet in block.
+    //! The index number of packet in a block.
     //!
-    //! Must be source_block_length < repair_symbol_id.
-    size_t repair_symbol_id;
+    //! @remarks
+    //!  Source packets are numbered in range [0; k).
+    //!  Repair packets are numbered in range [k; k + n), where
+    //!  k is a number of source packets per block (source_block_length)
+    //!  n is a number of repair packets per block.
+    size_t encoding_symbol_id;
 
     //! FECFRAME header or footer.
     core::Slice<uint8_t> payload_id;

--- a/src/modules/roc_packet/target_stdio/roc_packet/print.cpp
+++ b/src/modules/roc_packet/target_stdio/roc_packet/print.cpp
@@ -35,7 +35,9 @@ void print(const Packet& p, int flags) {
     }
 
     if (p.fec()) {
-        fprintf(stderr, "fec: blk=%lu payload=%lu\n", (unsigned long)p.fec()->blknum,
+        fprintf(stderr, "fec: sbn=%lu sblen=%lu payload=%lu\n",
+                (unsigned long)p.fec()->source_block_number,
+                (unsigned long)p.fec()->source_block_length,
                 (unsigned long)p.fec()->payload.size());
 
         if ((flags & PrintPayload) && p.fec()->payload) {

--- a/src/modules/roc_packet/units.h
+++ b/src/modules/roc_packet/units.h
@@ -87,6 +87,27 @@ static inline size_t num_channels(channel_mask_t ch_mask) {
     return n_ch;
 }
 
+//! FEC block number in a packet stream.
+typedef uint16_t blknum_t;
+
+//! FEC block numbers difference.
+typedef int16_t blknum_diff_t;
+
+//! Compute difference between two FEC block numbers.
+inline blknum_diff_t blknum_diff(blknum_t a, blknum_t b) {
+    return blknum_diff_t(a - b);
+}
+
+//! Check if a is before b taking possible wrap into account.
+inline bool blknum_lt(blknum_t a, blknum_t b) {
+    return blknum_diff(a, b) < 0;
+}
+
+//! Check if a is before or equal to b taking possible wrap into account.
+inline bool blknum_le(blknum_t a, blknum_t b) {
+    return blknum_diff(a, b) <= 0;
+}
+
 } // namespace packet
 } // namespace roc
 

--- a/src/tests/roc_packet/test_units.cpp
+++ b/src/tests/roc_packet/test_units.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <CppUTest/TestHarness.h>
+#include <stdio.h>
 
 #include "roc_packet/units.h"
 
@@ -117,6 +118,50 @@ TEST(units, num_channels) {
     LONGS_EQUAL(2, num_channels(Ch1 | Ch3));
 
     LONGS_EQUAL(3, num_channels(Ch1 | Ch2 | Ch3));
+}
+
+TEST(units, blknum_diff) {
+    const blknum_t v = 65535;
+
+    LONGS_EQUAL(0, blknum_diff(v, v));
+
+    LONGS_EQUAL(+1, blknum_diff(blknum_t(v + 1), v));
+    LONGS_EQUAL(-1, blknum_diff(blknum_t(v - 1), v));
+
+    CHECK(blknum_lt(v / 2, v));
+    CHECK(blknum_diff(v / 2, v) < 0);
+
+    CHECK(!blknum_lt(v / 2 - 1, v));
+    CHECK(blknum_diff(v / 2 - 1, v) > 0);
+}
+
+TEST(units, blknum_lt) {
+    const blknum_t v = 65535;
+
+    CHECK(blknum_lt(blknum_t(v - 1), v));
+    CHECK(blknum_lt(blknum_t(v - 5), v));
+
+    CHECK(!blknum_lt(blknum_t(v + 1), v));
+    CHECK(!blknum_lt(blknum_t(v + 5), v));
+
+    CHECK(blknum_lt(v / 2, v));
+    CHECK(!blknum_lt(v / 2 - 1, v));
+}
+
+TEST(units, blknum_le) {
+    const blknum_t v = 65535;
+
+    CHECK(!blknum_lt(v, v));
+    CHECK(blknum_le(v, v));
+
+    CHECK(blknum_le(blknum_t(v - 1), v));
+    CHECK(blknum_le(blknum_t(v - 5), v));
+
+    CHECK(!blknum_le(blknum_t(v + 1), v));
+    CHECK(!blknum_le(blknum_t(v + 5), v));
+
+    CHECK(blknum_le(v / 2, v));
+    CHECK(!blknum_le(v / 2 - 1, v));
 }
 
 } // namespace packet


### PR DESCRIPTION
#48

Doubts:

* I still need to use seqnum in the fec reader to ensure that packets via bad
  seqnum wan't be recovered.
* I do not want to use seqnum_t as a type for the source block number. It will
  be more reasonable to define a new type for it. I am not sure where to put
  this stuff. I only found roc_packet/units.h. Should we also define types for
  other fec-specific packet fields: source_block_length?