### PR TITLE
FEC: dynamic payload size

### DIFF
--- a/src/lib/include/roc/config.h
+++ b/src/lib/include/roc/config.h
@@ -312,12 +312,6 @@ typedef struct roc_receiver_config {
      */
     unsigned long long breakage_detection_window;
 
-    /** The length of the packets received from sender, in nanoseconds.
-     * Number of nanoseconds encoded per packet. If zero, default value is used.
-     * Should be set to the same value as on the sender.
-     */
-    unsigned long long packet_length;
-
     /** FEC code to use.
      * If non-zero, the receiver employs FEC codec to restore dropped packets.
      * This requires both sender and receiver to use two separate source and

--- a/src/lib/src/config.cpp
+++ b/src/lib/src/config.cpp
@@ -94,14 +94,14 @@ bool make_sender_config(pipeline::SenderConfig& out, const roc_sender_config& in
 
     switch ((int)in.fec_code) {
     case ROC_FEC_DISABLE:
-        out.fec.scheme = packet::FEC_None;
+        out.fec_encoder.scheme = packet::FEC_None;
         break;
     case ROC_FEC_DEFAULT:
     case ROC_FEC_RS8M:
-        out.fec.scheme = packet::FEC_ReedSolomon_M8;
+        out.fec_encoder.scheme = packet::FEC_ReedSolomon_M8;
         break;
     case ROC_FEC_LDPC_STAIRCASE:
-        out.fec.scheme = packet::FEC_LDPC_Staircase;
+        out.fec_encoder.scheme = packet::FEC_LDPC_Staircase;
         break;
     default:
         roc_log(LogError, "roc_config: invalid fec_scheme");
@@ -109,8 +109,8 @@ bool make_sender_config(pipeline::SenderConfig& out, const roc_sender_config& in
     }
 
     if (in.fec_block_source_packets != 0 || in.fec_block_repair_packets != 0) {
-        out.fec.n_source_packets = in.fec_block_source_packets;
-        out.fec.n_repair_packets = in.fec_block_repair_packets;
+        out.fec_writer.n_source_packets = in.fec_block_source_packets;
+        out.fec_writer.n_repair_packets = in.fec_block_repair_packets;
     }
 
     return true;
@@ -210,29 +210,24 @@ bool make_receiver_config(pipeline::ReceiverConfig& out, const roc_receiver_conf
             (core::nanoseconds_t)in.breakage_detection_window;
     }
 
-    if (in.packet_length != 0) {
-        out.default_session.packet_length = (core::nanoseconds_t)in.packet_length;
-    }
-
     switch ((int)in.fec_code) {
     case ROC_FEC_DISABLE:
-        out.default_session.fec.scheme = packet::FEC_None;
+        out.default_session.fec_decoder.scheme = packet::FEC_None;
         break;
     case ROC_FEC_DEFAULT:
     case ROC_FEC_RS8M:
-        out.default_session.fec.scheme = packet::FEC_ReedSolomon_M8;
+        out.default_session.fec_decoder.scheme = packet::FEC_ReedSolomon_M8;
         break;
     case ROC_FEC_LDPC_STAIRCASE:
-        out.default_session.fec.scheme = packet::FEC_LDPC_Staircase;
+        out.default_session.fec_decoder.scheme = packet::FEC_LDPC_Staircase;
         break;
     default:
         roc_log(LogError, "roc_config: invalid fec_scheme");
         return false;
     }
 
-    if (in.fec_block_source_packets != 0 || in.fec_block_repair_packets != 0) {
-        out.default_session.fec.n_source_packets = in.fec_block_source_packets;
-        out.default_session.fec.n_repair_packets = in.fec_block_repair_packets;
+    if (in.fec_block_repair_packets != 0) {
+        out.default_session.fec_reader.n_repair_packets = in.fec_block_repair_packets;
     }
 
     return true;

--- a/src/lib/src/sender.cpp
+++ b/src/lib/src/sender.cpp
@@ -61,7 +61,7 @@ bool sender_set_port(roc_sender* sender,
             return false;
         }
 
-        if (sender->config.fec.scheme == packet::FEC_None) {
+        if (sender->config.fec_encoder.scheme == packet::FEC_None) {
             roc_log(LogError,
                     "roc_sender: can't set audio repair port when fec is disabled");
             return false;
@@ -86,7 +86,7 @@ bool sender_check_connected(roc_sender* sender) {
     }
 
     if (sender->repair_port.protocol == pipeline::Proto_None
-        && sender->config.fec.scheme != packet::FEC_None) {
+        && sender->config.fec_encoder.scheme != packet::FEC_None) {
         roc_log(LogError, "roc_sender: repair port is not connected");
         return false;
     }

--- a/src/modules/roc_fec/codec_config.h
+++ b/src/modules/roc_fec/codec_config.h
@@ -6,11 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-//! @file roc_fec/config.h
-//! @brief FEC code type options.
+//! @file roc_fec/codec_config.h
+//! @brief FEC codec parameters.
 
-#ifndef ROC_FEC_CONFIG_H_
-#define ROC_FEC_CONFIG_H_
+#ifndef ROC_FEC_CODEC_CONFIG_H_
+#define ROC_FEC_CODEC_CONFIG_H_
 
 #include "roc_core/stddefs.h"
 #include "roc_packet/fec.h"
@@ -18,16 +18,10 @@
 namespace roc {
 namespace fec {
 
-//! FEC configuration.
-struct Config {
+//! FEC codec parameters.
+struct CodecConfig {
     //! FEC scheme.
     packet::FECScheme scheme;
-
-    //! Number of data packets in block.
-    size_t n_source_packets;
-
-    //! Number of FEC packets in block.
-    size_t n_repair_packets;
 
     //! Seed for LDPC scheme.
     int32_t ldpc_prng_seed;
@@ -38,21 +32,15 @@ struct Config {
     //! Configuration for ReedSolomon scheme.
     uint16_t rs_m;
 
-    //! Maximum allowed source block number jump.
-    size_t max_sbn_jump;
-
-    Config()
+    CodecConfig()
         : scheme(packet::FEC_None)
-        , n_source_packets(20)
-        , n_repair_packets(10)
         , ldpc_prng_seed(1297501556)
         , ldpc_N1(7)
-        , rs_m(8)
-        , max_sbn_jump(100) {
+        , rs_m(8) {
     }
 };
 
 } // namespace fec
 } // namespace roc
 
-#endif // ROC_FEC_CONFIG_H_
+#endif // ROC_FEC_CODEC_CONFIG_H_

--- a/src/modules/roc_fec/idecoder.h
+++ b/src/modules/roc_fec/idecoder.h
@@ -31,7 +31,7 @@ public:
     //! @remarks
     //!  Performs an initial setup for a block. Should be called before
     //!  any operations for the block.
-    virtual bool begin(size_t sblen, size_t rblen) = 0;
+    virtual bool begin(size_t sblen, size_t rblen, size_t payload_size) = 0;
 
     //! Store source or repair packet buffer for current block.
     virtual void set(size_t index, const core::Slice<uint8_t>& buffer) = 0;

--- a/src/modules/roc_fec/iencoder.h
+++ b/src/modules/roc_fec/iencoder.h
@@ -34,7 +34,7 @@ public:
     //! @remarks
     //!  Performs an initial setup for a block. Should be called before
     //!  any operations for the block.
-    virtual bool begin(size_t sblen, size_t rblen) = 0;
+    virtual bool begin(size_t sblen, size_t rblen, size_t payload_size) = 0;
 
     //! Store source or repair packet buffer for current block.
     virtual void set(size_t index, const core::Slice<uint8_t>& buffer) = 0;

--- a/src/modules/roc_fec/reader.h
+++ b/src/modules/roc_fec/reader.h
@@ -16,7 +16,6 @@
 #include "roc_core/iallocator.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/slice.h"
-#include "roc_fec/config.h"
 #include "roc_fec/idecoder.h"
 #include "roc_packet/iparser.h"
 #include "roc_packet/ireader.h"
@@ -26,6 +25,20 @@
 
 namespace roc {
 namespace fec {
+
+//! FEC reader parameters.
+struct ReaderConfig {
+    //! FIXME: remove this from config.
+    size_t n_repair_packets;
+
+    //! Maximum allowed source block number jump.
+    size_t max_sbn_jump;
+
+    ReaderConfig()
+        : n_repair_packets(10)
+        , max_sbn_jump(100) {
+    }
+};
 
 //! FEC reader.
 class Reader : public packet::IReader, public core::NonCopyable<> {
@@ -39,7 +52,7 @@ public:
     //!  - @p repair_reader specifies input queue with FEC packets;
     //!  - @p parser specifies packet parser for restored packets.
     //!  - @p allocator is used to initialize a packet array
-    Reader(const Config& config,
+    Reader(const ReaderConfig& config,
            IDecoder& decoder,
            packet::IReader& source_reader,
            packet::IReader& repair_reader,
@@ -67,6 +80,7 @@ private:
     packet::PacketPtr get_first_packet_();
     packet::PacketPtr get_next_packet_();
 
+    bool update_payload_size_(size_t);
     bool update_block_size_(size_t);
     void next_block_();
 
@@ -107,6 +121,8 @@ private:
 
     size_t next_packet_;
     packet::blknum_t cur_sbn_;
+
+    size_t payload_size_;
 
     bool has_source_;
     packet::source_t source_;

--- a/src/modules/roc_fec/target_openfec/roc_fec/of_decoder.cpp
+++ b/src/modules/roc_fec/target_openfec/roc_fec/of_decoder.cpp
@@ -43,6 +43,8 @@ OFDecoder::OFDecoder(const Config& config,
         codec_params_.rs_params_.m = config.rs_m;
 
         of_sess_params_ = (of_parameters_t*)&codec_params_.rs_params_;
+
+        max_block_length_ = OF_REED_SOLOMON_MAX_NB_ENCODING_SYMBOLS_DEFAULT;
     } else if (config.scheme == packet::FEC_LDPC_Staircase) {
         roc_log(LogDebug, "of decoder: initializing LDPC decoder");
 
@@ -51,6 +53,8 @@ OFDecoder::OFDecoder(const Config& config,
         codec_params_.ldpc_params_.N1 = config.ldpc_N1;
 
         of_sess_params_ = (of_parameters_t*)&codec_params_.ldpc_params_;
+
+        max_block_length_ = OF_LDPC_STAIRCASE_MAX_NB_ENCODING_SYMBOLS_DEFAULT;
     } else {
         roc_panic("of decoder: unexpected fec scheme");
     }
@@ -74,20 +78,7 @@ bool OFDecoder::valid() const {
 size_t OFDecoder::max_block_length() const {
     roc_panic_if_not(valid());
 
-    size_t ret = 0;
-
-    switch ((int)codec_id_) {
-    case OF_CODEC_REED_SOLOMON_GF_2_M_STABLE:
-        ret = OF_REED_SOLOMON_MAX_NB_ENCODING_SYMBOLS_DEFAULT;
-        break;
-    case OF_CODEC_LDPC_STAIRCASE_STABLE:
-        ret = OF_LDPC_STAIRCASE_MAX_NB_ENCODING_SYMBOLS_DEFAULT;
-        break;
-    default:
-        roc_panic("unexpected fec scheme");
-    }
-
-    return ret;
+    return max_block_length_;
 }
 
 bool OFDecoder::begin(size_t sblen, size_t rblen) {

--- a/src/modules/roc_fec/target_openfec/roc_fec/of_decoder.h
+++ b/src/modules/roc_fec/target_openfec/roc_fec/of_decoder.h
@@ -128,6 +128,8 @@ private:
     bool has_new_packets_;
     bool decoding_finished_;
 
+    size_t max_block_length_;
+
     bool valid_;
 };
 

--- a/src/modules/roc_fec/target_openfec/roc_fec/of_decoder.h
+++ b/src/modules/roc_fec/target_openfec/roc_fec/of_decoder.h
@@ -17,7 +17,7 @@
 #include "roc_core/iallocator.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/slice.h"
-#include "roc_fec/config.h"
+#include "roc_fec/codec_config.h"
 #include "roc_fec/idecoder.h"
 #include "roc_packet/units.h"
 
@@ -40,8 +40,7 @@ namespace fec {
 class OFDecoder : public IDecoder, public core::NonCopyable<> {
 public:
     //! Initialize.
-    explicit OFDecoder(const Config& config,
-                       size_t payload_size,
+    explicit OFDecoder(const CodecConfig& config,
                        core::BufferPool<uint8_t>& buffer_pool,
                        core::IAllocator& allocator);
 
@@ -58,7 +57,7 @@ public:
     //! @remarks
     //!  Performs an initial setup for a block. Should be called before
     //!  any operations for the block.
-    virtual bool begin(size_t sblen, size_t rblen);
+    virtual bool begin(size_t sblen, size_t rblen, size_t payload_size);
 
     //! Store source or repair packet buffer for current block.
     virtual void set(size_t index, const core::Slice<uint8_t>& buffer);
@@ -74,7 +73,7 @@ public:
     virtual void end();
 
 private:
-    void update_session_params_(size_t sblen, size_t rblen);
+    void update_session_params_(size_t sblen, size_t rblen, size_t payload_size);
 
     void reset_tabs_();
     bool resize_tabs_(size_t size);
@@ -98,7 +97,7 @@ private:
 
     size_t sblen_;
     size_t rblen_;
-    const size_t payload_size_;
+    size_t payload_size_;
 
     of_codec_id_t codec_id_;
     union {

--- a/src/modules/roc_fec/target_openfec/roc_fec/of_encoder.cpp
+++ b/src/modules/roc_fec/target_openfec/roc_fec/of_encoder.cpp
@@ -29,6 +29,8 @@ OFEncoder::OFEncoder(const Config& config,
         codec_params_.rs_params_.m = config.rs_m;
 
         of_sess_params_ = (of_parameters_t*)&codec_params_.rs_params_;
+
+        max_block_length_ = OF_REED_SOLOMON_MAX_NB_ENCODING_SYMBOLS_DEFAULT;
     } else if (config.scheme == packet::FEC_LDPC_Staircase) {
         roc_log(LogDebug, "of encoder: initializing LDPC encoder");
 
@@ -37,6 +39,8 @@ OFEncoder::OFEncoder(const Config& config,
         codec_params_.ldpc_params_.N1 = config.ldpc_N1;
 
         of_sess_params_ = (of_parameters_t*)&codec_params_.ldpc_params_;
+
+        max_block_length_ = OF_LDPC_STAIRCASE_MAX_NB_ENCODING_SYMBOLS_DEFAULT;
     } else {
         roc_panic("of encoder: unexpected fec scheme");
     }
@@ -64,20 +68,7 @@ size_t OFEncoder::alignment() const {
 size_t OFEncoder::max_block_length() const {
     roc_panic_if_not(valid());
 
-    size_t ret = 0;
-
-    switch ((int)codec_id_) {
-    case OF_CODEC_REED_SOLOMON_GF_2_M_STABLE:
-        ret = OF_REED_SOLOMON_MAX_NB_ENCODING_SYMBOLS_DEFAULT;
-        break;
-    case OF_CODEC_LDPC_STAIRCASE_STABLE:
-        ret = OF_LDPC_STAIRCASE_MAX_NB_ENCODING_SYMBOLS_DEFAULT;
-        break;
-    default:
-        roc_panic("unexpected fec scheme");
-    }
-
-    return ret;
+    return max_block_length_;
 }
 
 bool OFEncoder::begin(size_t sblen, size_t rblen) {

--- a/src/modules/roc_fec/target_openfec/roc_fec/of_encoder.h
+++ b/src/modules/roc_fec/target_openfec/roc_fec/of_encoder.h
@@ -17,7 +17,7 @@
 #include "roc_core/iallocator.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/slice.h"
-#include "roc_fec/config.h"
+#include "roc_fec/codec_config.h"
 #include "roc_fec/iencoder.h"
 #include "roc_packet/units.h"
 
@@ -40,9 +40,7 @@ namespace fec {
 class OFEncoder : public IEncoder, public core::NonCopyable<> {
 public:
     //! Initialize.
-    explicit OFEncoder(const Config& config,
-                       size_t payload_size,
-                       core::IAllocator& allocator);
+    explicit OFEncoder(const CodecConfig& config, core::IAllocator& allocator);
 
     virtual ~OFEncoder();
 
@@ -60,7 +58,7 @@ public:
     //! @remarks
     //!  Performs an initial setup for a block. Should be called before
     //!  any operations for the block.
-    virtual bool begin(size_t sblen, size_t rblen);
+    virtual bool begin(size_t sblen, size_t rblen, size_t payload_size);
 
     //! Store packet data for current block.
     virtual void set(size_t index, const core::Slice<uint8_t>& buffer);
@@ -78,12 +76,14 @@ public:
 private:
     bool resize_tabs_(size_t size);
     void reset_session_();
-    void update_session_params_(size_t sblen, size_t rblen);
+    void update_session_params_(size_t sblen, size_t rblen, size_t payload_size);
 
     enum { Alignment = 8 };
 
     size_t sblen_;
     size_t rblen_;
+
+    size_t payload_size_;
 
     of_session_t* of_sess_;
     of_parameters_t* of_sess_params_;

--- a/src/modules/roc_fec/target_openfec/roc_fec/of_encoder.h
+++ b/src/modules/roc_fec/target_openfec/roc_fec/of_encoder.h
@@ -97,6 +97,8 @@ private:
     core::Array<core::Slice<uint8_t> > buff_tab_;
     core::Array<void*> data_tab_;
 
+    size_t max_block_length_;
+
     bool valid_;
 };
 

--- a/src/modules/roc_pipeline/config.h
+++ b/src/modules/roc_pipeline/config.h
@@ -17,7 +17,9 @@
 #include "roc_audio/watchdog.h"
 #include "roc_core/stddefs.h"
 #include "roc_core/time.h"
-#include "roc_fec/config.h"
+#include "roc_fec/codec_config.h"
+#include "roc_fec/reader.h"
+#include "roc_fec/writer.h"
 #include "roc_packet/units.h"
 #include "roc_pipeline/port.h"
 #include "roc_rtp/headers.h"
@@ -68,8 +70,11 @@ struct SenderConfig {
     //! Resampler parameters.
     audio::ResamplerConfig resampler;
 
-    //! FEC scheme parameters.
-    fec::Config fec;
+    //! FEC writer parameters.
+    fec::WriterConfig fec_writer;
+
+    //! FEC encoder parameters.
+    fec::CodecConfig fec_encoder;
 
     //! Number of samples per second per channel.
     size_t input_sample_rate;
@@ -124,11 +129,11 @@ struct ReceiverSessionConfig {
     //! Packet payload type.
     unsigned int payload_type;
 
-    //! Packet length, in nanoseconds.
-    core::nanoseconds_t packet_length;
+    //! FEC reader parameters.
+    fec::ReaderConfig fec_reader;
 
-    //! FEC scheme parameters.
-    fec::Config fec;
+    //! FEC decoder parameters.
+    fec::CodecConfig fec_decoder;
 
     //! RTP validator parameters.
     rtp::ValidatorConfig rtp_validator;
@@ -145,8 +150,7 @@ struct ReceiverSessionConfig {
     ReceiverSessionConfig()
         : target_latency(DefaultLatency)
         , channels(DefaultChannelMask)
-        , payload_type(0)
-        , packet_length(DefaultPacketLength) {
+        , payload_type(0) {
         latency_monitor.min_latency = target_latency * DefaultMinLatencyFactor;
         latency_monitor.max_latency = target_latency * DefaultMaxLatencyFactor;
     }

--- a/src/modules/roc_pipeline/receiver.cpp
+++ b/src/modules/roc_pipeline/receiver.cpp
@@ -284,7 +284,7 @@ Receiver::make_session_config_(const packet::PacketPtr& packet) const {
 
     packet::FEC* fec = packet->fec();
     if (fec) {
-        sess_config.fec.scheme = fec->fec_scheme;
+        sess_config.fec_decoder.scheme = fec->fec_scheme;
     }
 
     return sess_config;

--- a/src/modules/roc_pipeline/receiver_session.cpp
+++ b/src/modules/roc_pipeline/receiver_session.cpp
@@ -69,7 +69,7 @@ ReceiverSession::ReceiverSession(const ReceiverSessionConfig& session_config,
     preader = validator_.get();
 
 #ifdef ROC_TARGET_OPENFEC
-    if (session_config.fec.scheme != packet::FEC_None) {
+    if (session_config.fec_decoder.scheme != packet::FEC_None) {
         repair_queue_.reset(new (allocator_) packet::SortedQueue(0), allocator_);
         if (!repair_queue_) {
             return;
@@ -79,9 +79,8 @@ ReceiverSession::ReceiverSession(const ReceiverSessionConfig& session_config,
         }
 
         core::UniquePtr<fec::OFDecoder> fec_decoder(
-            new (allocator_) fec::OFDecoder(session_config.fec,
-                                            format->size(session_config.packet_length),
-                                            byte_buffer_pool, allocator_),
+            new (allocator_)
+                fec::OFDecoder(session_config.fec_decoder, byte_buffer_pool, allocator_),
             allocator_);
         if (!fec_decoder || !fec_decoder->valid()) {
             return;
@@ -94,8 +93,8 @@ ReceiverSession::ReceiverSession(const ReceiverSessionConfig& session_config,
         }
 
         fec_reader_.reset(new (allocator_) fec::Reader(
-                              session_config.fec, *fec_decoder_, *preader, *repair_queue_,
-                              *fec_parser_, packet_pool, allocator_),
+                              session_config.fec_reader, *fec_decoder_, *preader,
+                              *repair_queue_, *fec_parser_, packet_pool, allocator_),
                           allocator_);
         if (!fec_reader_ || !fec_reader_->valid()) {
             return;

--- a/src/tests/roc_fec/target_openfec/test_encoder_decoder.cpp
+++ b/src/tests/roc_fec/target_openfec/test_encoder_decoder.cpp
@@ -192,6 +192,8 @@ TEST(encoder_decoder, max_source_block) {
     size_t test_cases[] = { OF_REED_SOLOMON_MAX_NB_ENCODING_SYMBOLS_DEFAULT,
                             OF_LDPC_STAIRCASE_MAX_NB_ENCODING_SYMBOLS_DEFAULT };
 
+    CHECK(ROC_ARRAY_SIZE(test_cases) == Test_n_fec_schemes);
+
     for (size_t n_scheme = 0; n_scheme < Test_n_fec_schemes; ++n_scheme) {
         config.scheme = Test_fec_schemes[n_scheme];
         Codec code(config);

--- a/src/tests/roc_fec/target_openfec/test_packet_dispatcher.h
+++ b/src/tests/roc_fec/target_openfec/test_packet_dispatcher.h
@@ -63,6 +63,11 @@ public:
         return repair_queue_.head();
     }
 
+    void resize(size_t num_source, size_t num_repair) {
+        num_source_ = num_source;
+        num_repair_ = num_repair;
+    }
+
     void reset() {
         const size_t n_source_packets = source_queue_.size();
         const size_t n_repair_packets = repair_queue_.size();
@@ -175,8 +180,8 @@ private:
         return false;
     }
 
-    const size_t num_source_;
-    const size_t num_repair_;
+    size_t num_source_;
+    size_t num_repair_;
 
     size_t packet_num_;
 

--- a/src/tests/roc_fec/target_openfec/test_packet_dispatcher.h
+++ b/src/tests/roc_fec/target_openfec/test_packet_dispatcher.h
@@ -102,7 +102,7 @@ public:
         n_delayed_ = 0;
     }
 
-    void push_written() {
+    void push_stocks() {
         while (source_stock_.head()) {
             source_queue_.write(source_stock_.read());
         }
@@ -111,18 +111,17 @@ public:
         }
     }
 
-    bool push_one_source() {
-        packet::PacketPtr p;
-        if (!(p = source_stock_.read())) {
-            return false;
+    void push_source_stock(size_t limit) {
+        for (size_t n = 0; n < limit; n++) {
+            packet::PacketPtr p = source_stock_.read();
+            CHECK(p);
+            source_queue_.write(p);
         }
-        source_queue_.write(p);
-        return true;
     }
 
-    void push_delayed(const size_t n) {
+    void push_delayed(const size_t index) {
         for (size_t i = 0; i < n_delayed_; i++) {
-            if (delayed_packet_nums_[i] == n) {
+            if (delayed_packet_nums_[i] == index) {
                 if (delayed_stock_[i]) {
                     route_(source_queue_, repair_queue_, delayed_stock_[i]);
                     delayed_stock_[i] = NULL;

--- a/src/tests/roc_lib/test_sender_receiver.cpp
+++ b/src/tests/roc_lib/test_sender_receiver.cpp
@@ -385,9 +385,6 @@ TEST_GROUP(sender_receiver) {
         receiver_conf.resampler_profile = ROC_RESAMPLER_DISABLE;
         receiver_conf.target_latency = Latency * 1000000000ul / SampleRate;
         receiver_conf.no_playback_timeout = Timeout * 1000000000ul / SampleRate;
-        receiver_conf.packet_length =
-            PacketSamples * 1000000000ul / (SampleRate * NumChans);
-        receiver_conf.fec_code = ROC_FEC_RS8M;
         receiver_conf.fec_block_source_packets = SourcePackets;
         receiver_conf.fec_block_repair_packets = RepairPackets;
     }

--- a/src/tests/roc_pipeline/test_receiver.cpp
+++ b/src/tests/roc_pipeline/test_receiver.cpp
@@ -75,11 +75,7 @@ TEST_GROUP(receiver) {
         config.common.timing = false;
         config.common.poisoning = true;
 
-        config.default_session.fec.scheme = packet::FEC_None;
-
         config.default_session.channels = ChMask;
-        config.default_session.packet_length =
-            SamplesPerPacket * core::Second / SampleRate;
 
         config.default_session.target_latency = Latency * core::Second / SampleRate;
 

--- a/src/tests/roc_pipeline/test_sender_receiver.cpp
+++ b/src/tests/roc_pipeline/test_sender_receiver.cpp
@@ -216,15 +216,15 @@ TEST_GROUP(sender_receiver) {
         config.internal_frame_size = MaxBufSize;
 
         if (flags & FlagReedSolomon) {
-            config.fec.scheme = packet::FEC_ReedSolomon_M8;
+            config.fec_encoder.scheme = packet::FEC_ReedSolomon_M8;
         }
 
         if (flags & FlagLDPC) {
-            config.fec.scheme = packet::FEC_LDPC_Staircase;
+            config.fec_encoder.scheme = packet::FEC_LDPC_Staircase;
         }
 
-        config.fec.n_source_packets = SourcePackets;
-        config.fec.n_repair_packets = RepairPackets;
+        config.fec_writer.n_source_packets = SourcePackets;
+        config.fec_writer.n_repair_packets = RepairPackets;
 
         config.interleaving = (flags & FlagInterleaving);
         config.timing = false;
@@ -245,15 +245,12 @@ TEST_GROUP(sender_receiver) {
         config.common.poisoning = true;
 
         config.default_session.channels = ChMask;
-        config.default_session.packet_length =
-            SamplesPerPacket * core::Second / SampleRate;
 
         config.default_session.target_latency = Latency * core::Second / SampleRate;
         config.default_session.watchdog.no_playback_timeout =
             Timeout * core::Second / SampleRate;
 
-        config.default_session.fec.n_source_packets = SourcePackets;
-        config.default_session.fec.n_repair_packets = RepairPackets;
+        config.default_session.fec_reader.n_repair_packets = RepairPackets;
 
         return config;
     }

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -66,7 +66,6 @@ int main(int argc, char** argv) {
             roc_log(LogError, "invalid --nbsrc: should be > 0");
             return 1;
         }
-        config.default_session.fec.n_source_packets = (size_t)args.nbsrc_arg;
     }
 
     if (args.nbrpr_given) {
@@ -74,7 +73,7 @@ int main(int argc, char** argv) {
             roc_log(LogError, "invalid --nbrpr: should be > 0");
             return 1;
         }
-        config.default_session.fec.n_repair_packets = (size_t)args.nbrpr_arg;
+        config.default_session.fec_reader.n_repair_packets = (size_t)args.nbrpr_arg;
     }
 
     if (args.sess_latency_given) {

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -87,15 +87,15 @@ int main(int argc, char** argv) {
 
     switch ((unsigned)args.fec_arg) {
     case fec_arg_none:
-        config.fec.scheme = packet::FEC_None;
+        config.fec_encoder.scheme = packet::FEC_None;
         break;
 
     case fec_arg_rs8m:
-        config.fec.scheme = packet::FEC_ReedSolomon_M8;
+        config.fec_encoder.scheme = packet::FEC_ReedSolomon_M8;
         break;
 
     case fec_arg_ldpc:
-        config.fec.scheme = packet::FEC_LDPC_Staircase;
+        config.fec_encoder.scheme = packet::FEC_LDPC_Staircase;
         break;
 
     default:
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
     }
 
     if (args.nbsrc_given) {
-        if (config.fec.scheme == packet::FEC_None) {
+        if (config.fec_encoder.scheme == packet::FEC_None) {
             roc_log(LogError, "--nbsrc can't be used when --fec=none)");
             return 1;
         }
@@ -111,11 +111,11 @@ int main(int argc, char** argv) {
             roc_log(LogError, "invalid --nbsrc: should be > 0");
             return 1;
         }
-        config.fec.n_source_packets = (size_t)args.nbsrc_arg;
+        config.fec_writer.n_source_packets = (size_t)args.nbsrc_arg;
     }
 
     if (args.nbrpr_given) {
-        if (config.fec.scheme == packet::FEC_None) {
+        if (config.fec_encoder.scheme == packet::FEC_None) {
             roc_log(LogError, "--nbrpr can't be used when --fec=none");
             return 1;
         }
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
             roc_log(LogError, "invalid --nbrpr: should be > 0");
             return 1;
         }
-        config.fec.n_repair_packets = (size_t)args.nbrpr_arg;
+        config.fec_writer.n_repair_packets = (size_t)args.nbrpr_arg;
     }
 
     config.resampling = !args.no_resampling_flag;


### PR DESCRIPTION
Handle dynamic packet size in reader and writer (#180). Plus some refactoring. See commit messages.

Not all tests for dynamic payload size are ready yet; this will take some time. I suggest to merge this now and add tests in next PR because this way we can avoid conflicts with upcoming dynamic rblen support.