### PR TITLE
Fix watchdog drop detection

### DIFF
--- a/src/modules/roc_audio/watchdog.cpp
+++ b/src/modules/roc_audio/watchdog.cpp
@@ -159,9 +159,12 @@ void Watchdog::update_drops_timeout_(const Frame& frame,
     const packet::timestamp_t window_end = window_start + drop_detection_window_;
 
     if (packet::timestamp_le(window_end, next_read_pos)) {
-        if ((curr_window_flags_ & (Frame::FlagIncomplete | Frame::FlagDrops)) == 0) {
+        const unsigned drop_flags = Frame::FlagIncomplete | Frame::FlagDrops;
+
+        if ((curr_window_flags_ & drop_flags) != drop_flags) {
             last_pos_before_drops_ = next_read_pos;
         }
+
         if (next_read_pos % drop_detection_window_ == 0) {
             curr_window_flags_ = 0;
         } else {

--- a/src/tests/roc_audio/test_watchdog.cpp
+++ b/src/tests/roc_audio/test_watchdog.cpp
@@ -217,7 +217,34 @@ TEST(watchdog, broken_playback_timeout_equal_frame_sizes) {
 
         check_n_reads(watchdog, true, BreakageWindow, BreakageWindowsPerTimeout - 1,
                       Frame::FlagIncomplete | Frame::FlagDrops);
+        check_read(watchdog, true, BreakageWindow, Frame::FlagIncomplete);
+
+        CHECK(watchdog.update());
+        check_read(watchdog, true, BreakageWindow, 0);
+    }
+    {
+        Watchdog watchdog(test_reader, NumCh,
+                          make_config(NoPlaybackTimeout, BrokenPlaybackTimeout),
+                          SampleRate, allocator);
+        CHECK(watchdog.valid());
+
+        check_n_reads(watchdog, true, BreakageWindow, BreakageWindowsPerTimeout - 1,
+                      Frame::FlagIncomplete | Frame::FlagDrops);
         check_read(watchdog, true, BreakageWindow, Frame::FlagDrops);
+
+        CHECK(watchdog.update());
+        check_read(watchdog, true, BreakageWindow, 0);
+    }
+    {
+        Watchdog watchdog(test_reader, NumCh,
+                          make_config(NoPlaybackTimeout, BrokenPlaybackTimeout),
+                          SampleRate, allocator);
+        CHECK(watchdog.valid());
+
+        check_n_reads(watchdog, true, BreakageWindow, BreakageWindowsPerTimeout - 1,
+                      Frame::FlagIncomplete | Frame::FlagDrops);
+        check_read(watchdog, true, BreakageWindow,
+                   Frame::FlagIncomplete | Frame::FlagDrops);
 
         CHECK(!watchdog.update());
         check_read(watchdog, false, BreakageWindow, 0);


### PR DESCRIPTION
Fixes #163.

It seems that it was just a silly error in update_drops_timeout_(). I've fixed it, fixed one incorrect test, and added tests for this bug.

Also tested it manually using two methods:

* hacking sender to emulate delays between packets;
* loading CPU on sender to create real delays.

Now everything works as before but without false positives.

The second commit is an unrelated cosmetic fix in tests.