### PR TITLE
roc_core: Print time in log messages

### DIFF
--- a/src/modules/roc_core/target_posix/roc_core/format_time.cpp
+++ b/src/modules/roc_core/target_posix/roc_core/format_time.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <stdio.h>
+#include <sys/time.h>
+#include <time.h>
+
+#include "roc_core/format_time.h"
+
+namespace roc {
+namespace core {
+
+bool format_time(char* buf, size_t bufsz) {
+    timeval tv;
+    if (gettimeofday(&tv, NULL) == -1) {
+        return false;
+    }
+
+    tm t;
+    if (!localtime_r(&tv.tv_sec, &t)) {
+        return false;
+    }
+
+    size_t off = strftime(buf, bufsz, "%H:%M:%S", &t);
+    if (off == 0) {
+        return false;
+    }
+
+    if (off == bufsz) {
+        return false;
+    }
+
+    int ret =
+        snprintf(buf + off, bufsz - off, ".%03lu", (unsigned long)tv.tv_usec / 1000);
+    if (ret <= 0 || (size_t)ret >= (bufsz - off)) {
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace core
+} // namespace roc

--- a/src/modules/roc_core/target_posix/roc_core/format_time.h
+++ b/src/modules/roc_core/target_posix/roc_core/format_time.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_core/target_posix/roc_core/format_time.h
+//! @brief Retrieve and format current time.
+
+#ifndef ROC_CORE_FORMAT_TIME_H_
+#define ROC_CORE_FORMAT_TIME_H_
+
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace core {
+
+//! Retrieve and format current time.
+//
+//! @remarks
+//!  The time is printed in the format "13:10:05.123".
+//!
+//! @returns
+//!  false if an error occured or buffer is too small.
+//!
+//! @note
+//!  This function should not log anything because it is used
+//!  in the logger implementation.
+bool format_time(char* buf, size_t bufsz);
+
+} // namespace core
+} // namespace roc
+
+#endif // ROC_CORE_FORMAT_TIME_H_

--- a/src/tests/roc_core/target_posix/test_format_time.cpp
+++ b/src/tests/roc_core/target_posix/test_format_time.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <CppUTest/TestHarness.h>
+
+#include "roc_core/format_time.h"
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace core {
+
+namespace {
+
+enum {
+    // Timestamp length, including zero terminator.
+    TsLen = sizeof("00:00:00.000")
+};
+
+} // namespace
+
+TEST_GROUP(format_time) {};
+
+TEST(format_time, buffer_size) {
+    char buf[64];
+
+    for (size_t i = 0; i < TsLen; i++) {
+        CHECK(!format_time(buf, i));
+    }
+
+    for (size_t i = TsLen; i < sizeof(buf); i++) {
+        CHECK(format_time(buf, i));
+    }
+}
+
+TEST(format_time, zero_terminator) {
+    char buf[64];
+    memset(buf, 'x', sizeof(buf));
+
+    CHECK(format_time(buf, sizeof(buf) - 10));
+
+    for (size_t i = 0; i < TsLen - 1; i++) {
+        CHECK(buf[i] != '\0' && buf[i] != 'x');
+    }
+
+    CHECK(buf[TsLen - 1] == '\0');
+
+    for (size_t i = TsLen; i < sizeof(buf); i++) {
+        CHECK(buf[i] == 'x');
+    }
+}
+
+} // namespace core
+} // namespace roc


### PR DESCRIPTION
For #69.

Example:

```
$ roc-send -vv -s rtp+rs8m:127.0.0.1:10001 -r rs8m:127.0.0.1:10002 -i ~/stash/short.wav
19:25:11.137 [dbg] roc_sndio: initializing pulseaudio backend
19:25:11.137 [dbg] roc_sndio: initializing sox backend
19:25:11.137 [dbg] roc_send: pool: initializing: object_size=2064 poison=0
19:25:11.137 [dbg] roc_send: pool: initializing: object_size=2576 poison=0
19:25:11.137 [dbg] roc_send: pool: initializing: object_size=608 poison=0
19:25:11.137 [inf] roc_sndio: sox source: opening: driver=(null) input=/home/victor/stash/short.wav
19:25:11.137 [dbg] roc_sndio: sox: formats.c: detected file format type `wav'
19:25:11.137 [inf] roc_sndio: sox source: in_bits=16 out_bits=32 in_rate=44100 out_rate=0 in_ch=2 out_ch=0 is_file=1
19:25:11.137 [inf] roc_netio: udp sender: opened port 0.0.0.0:57118
19:25:11.137 [dbg] roc_fec: of encoder: initializing: codec=rs m=8
19:25:11.137 [dbg] roc_fec: fec writer: update block size: cur_sbl=0 cur_rbl=0 new_sbl=20 new_rbl=10 payload_size=1248
19:25:11.137 [dbg] roc_audio: packetizer: initializing: n_channels=2 samples_per_packet=309
19:25:11.137 [dbg] roc_sndio: pump: starting main loop
19:25:11.137 [dbg] roc_netio: transceiver: starting event loop
19:25:11.138 [dbg] roc_packet: router: detected new stream: source=181476276 flags=0x8u
19:25:11.276 [dbg] roc_packet: router: detected new stream: source=0 flags=0x10u
19:25:12.124 [dbg] roc_sndio: sox source: got eof from sox
19:25:12.132 [dbg] roc_sndio: pump: got eof from source
19:25:12.132 [dbg] roc_sndio: pump: exiting main loop, wrote 139 buffers
19:25:12.132 [inf] roc_netio: udp sender: closing port 0.0.0.0:57118
19:25:12.132 [dbg] roc_netio: transceiver: finishing event loop
19:25:12.132 [inf] roc_sndio: sox source: closing input
```