### PR TITLE
Rework audio encoder and decoder interfaces

### DIFF
--- a/.fmtignore
+++ b/.fmtignore
@@ -1,5 +1,7 @@
 src/tests/roc_audio/test_depacketizer.cpp
 src/tests/roc_audio/test_mixer.cpp
+src/tests/roc_audio/test_packetizer.cpp
+src/tests/roc_fec/test_composer_parser.cpp
 src/tests/roc_netio/test_udp.cpp
 src/tests/roc_packet/test_concurrent_queue.cpp
 src/tests/roc_packet/test_delayed_reader.cpp
@@ -8,8 +10,9 @@ src/tests/roc_packet/test_router.cpp
 src/tests/roc_packet/test_sorted_queue.cpp
 src/tests/roc_packet/test_watchdog.cpp
 src/tests/roc_pipeline/test_sender_receiver.cpp
+src/tests/roc_rtp/test_composer_parser.cpp
+src/tests/roc_rtp/test_encoder_decoder.cpp
 src/tests/roc_rtp/test_packets.cpp
 src/tests/roc_rtp/test_packets/*.h
-src/tests/roc_fec/test_composer_parser.cpp
 src/tests/roc_sndio/target_sox/test_player_recorder.cpp
 src/tests/roc_sndio/target_sox/test_writer_reader.cpp

--- a/src/modules/roc_audio/depacketizer.h
+++ b/src/modules/roc_audio/depacketizer.h
@@ -64,16 +64,12 @@ private:
                           packet::timestamp_t prev_packet_samples);
 
     void update_packet_();
-    packet::PacketPtr read_packet_();
 
     packet::IReader& reader_;
     IDecoder& decoder_;
 
     const packet::channel_mask_t channels_;
     const size_t num_channels_;
-
-    packet::PacketPtr packet_;
-    packet::timestamp_t packet_pos_;
 
     packet::timestamp_t timestamp_;
 
@@ -84,6 +80,8 @@ private:
     core::RateLimiter rate_limiter_;
 
     bool first_packet_;
+    bool has_packet_;
+
     bool beep_;
 
     size_t dropped_packets_;

--- a/src/modules/roc_audio/packetizer.h
+++ b/src/modules/roc_audio/packetizer.h
@@ -33,17 +33,6 @@ namespace audio {
 class Packetizer : public IWriter, public core::NonCopyable<> {
 public:
     //! Initialization.
-    //!
-    //! @b Parameters
-    //!  - @p writer is used to write generated packets
-    //!  - @p composer is used to initialize new packets
-    //!  - @p encoder is used to write samples to packets
-    //!  - @p packet_pool is used to allocate packets
-    //!  - @p buffer_pool is used to allocate buffers for packets
-    //!  - @p channels defines a set of channels in the input frames
-    //!  - @p packet_length defines packet length in nanoseconds
-    //!  - @p sample_rate defines number of samples per channel per second
-    //!  - @p payload_type defines packet payload type
     Packetizer(packet::IWriter& writer,
                packet::IComposer& composer,
                IEncoder& encoder,
@@ -51,20 +40,21 @@ public:
                core::BufferPool<uint8_t>& buffer_pool,
                packet::channel_mask_t channels,
                core::nanoseconds_t packet_length,
-               size_t sample_rate,
-               unsigned int payload_type);
+               size_t sample_rate);
 
     //! Write audio frame.
     virtual void write(Frame& frame);
 
     //! Flush buffered packet, if any.
     //! @remarks
-    //!  Packet is padded with zero samples to match fixed size.
+    //!  Packet payload is padded if necessary to match configured payload size.
     void flush();
 
 private:
-    packet::PacketPtr start_packet_();
-    bool finish_packet_();
+    bool begin_packet_();
+    void end_packet_();
+
+    packet::PacketPtr create_packet_();
 
     packet::IWriter& writer_;
     packet::IComposer& composer_;
@@ -75,14 +65,9 @@ private:
     const packet::channel_mask_t channels_;
     const size_t num_channels_;
     const size_t samples_per_packet_;
-    const unsigned int payload_type_;
 
     packet::PacketPtr packet_;
-    size_t packet_pos_;
-
-    const packet::source_t source_;
-    packet::seqnum_t seqnum_;
-    packet::timestamp_t timestamp_;
+    size_t remaining_samples_;
 };
 
 } // namespace audio

--- a/src/modules/roc_pipeline/receiver_session.cpp
+++ b/src/modules/roc_pipeline/receiver_session.cpp
@@ -115,7 +115,7 @@ ReceiverSession::ReceiverSession(const ReceiverSessionConfig& session_config,
     }
 #endif // ROC_TARGET_OPENFEC
 
-    decoder_.reset(format->new_decoder(allocator_), allocator_);
+    decoder_.reset(format->new_decoder(allocator_, *format), allocator_);
     if (!decoder_) {
         return;
     }

--- a/src/modules/roc_rtp/format.h
+++ b/src/modules/roc_rtp/format.h
@@ -37,17 +37,14 @@ struct Format {
     //! Channel mask.
     packet::channel_mask_t channel_mask;
 
-    //! Get packet duration in samples.
-    packet::timestamp_t (*duration)(const packet::RTP&);
-
-    //! Get packet size in bytes for given duration in nanoseconds.
-    size_t (*size)(core::nanoseconds_t duration);
+    //! Get number of samples per channel from payload size in bytes.
+    size_t (*get_num_samples)(size_t payload_size);
 
     //! Create encoder.
-    audio::IEncoder* (*new_encoder)(core::IAllocator& allocator);
+    audio::IEncoder* (*new_encoder)(core::IAllocator& allocator, const Format& format);
 
     //! Create decoder.
-    audio::IDecoder* (*new_decoder)(core::IAllocator& allocator);
+    audio::IDecoder* (*new_decoder)(core::IAllocator& allocator, const Format& format);
 };
 
 } // namespace rtp

--- a/src/modules/roc_rtp/format_map.cpp
+++ b/src/modules/roc_rtp/format_map.cpp
@@ -7,50 +7,81 @@
  */
 
 #include "roc_rtp/format_map.h"
+#include "roc_core/panic.h"
 #include "roc_rtp/pcm_decoder.h"
 #include "roc_rtp/pcm_encoder.h"
-#include "roc_rtp/pcm_helpers.h"
+#include "roc_rtp/pcm_funcs.h"
 
 namespace roc {
 namespace rtp {
 
 namespace {
 
-Format pcm_l16_stereo = {
-    /* payload_type */ PayloadType_L16_Stereo,
-    /* flags        */ packet::Packet::FlagAudio,
-    /* sample_rate  */ 44100,
-    /* channel_mask */ 0x3,
-    /* duration     */ &pcm_duration_from_header<int16_t, 2>,
-    /* size         */ &pcm_packet_size_from_duration<int16_t, 2, 44100>,
-    /* new_encoder  */ &PCMEncoder<int16_t, 2>::create,
-    /* new_decoder  */ &PCMDecoder<int16_t, 2>::create,
-};
+// PCM 16-bit 2ch
 
-Format pcm_l16_mono = {
-    /* payload_type */ PayloadType_L16_Mono,
-    /* flags        */ packet::Packet::FlagAudio,
-    /* sample_rate  */ 44100,
-    /* channel_mask */ 0x1,
-    /* duration     */ &pcm_duration_from_header<int16_t, 1>,
-    /* size         */ &pcm_packet_size_from_duration<int16_t, 1, 44100>,
-    /* new_encoder  */ &PCMEncoder<int16_t, 1>::create,
-    /* new_decoder  */ &PCMDecoder<int16_t, 1>::create,
-};
+audio::IEncoder* new_encoder_pcm_16bit_2ch(core::IAllocator& allocator,
+                                           const Format& format) {
+    return new (allocator) PCMEncoder(PCM_16bit_2ch, format);
+}
+
+audio::IDecoder* new_decoder_pcm_16bit_2ch(core::IAllocator& allocator,
+                                           const Format& format) {
+    return new (allocator) PCMDecoder(PCM_16bit_2ch, format);
+}
+
+// PCM 16-bit 1ch
+
+audio::IEncoder* new_encoder_pcm_16bit_1ch(core::IAllocator& allocator,
+                                           const Format& format) {
+    return new (allocator) PCMEncoder(PCM_16bit_1ch, format);
+}
+
+audio::IDecoder* new_decoder_pcm_16bit_1ch(core::IAllocator& allocator,
+                                           const Format& format) {
+    return new (allocator) PCMDecoder(PCM_16bit_1ch, format);
+}
 
 } // namespace
 
-const Format* FormatMap::format(unsigned int pt) const {
-    switch (pt) {
-    case PayloadType_L16_Stereo:
-        return &pcm_l16_stereo;
-
-    case PayloadType_L16_Mono:
-        return &pcm_l16_mono;
-
-    default:
-        return NULL;
+FormatMap::FormatMap()
+    : n_formats_(0) {
+    {
+        Format fmt;
+        fmt.payload_type = PayloadType_L16_Stereo;
+        fmt.flags = packet::Packet::FlagAudio;
+        fmt.sample_rate = 44100;
+        fmt.channel_mask = 0x3;
+        fmt.get_num_samples = PCM_16bit_2ch.samples_from_payload_size;
+        fmt.new_encoder = new_encoder_pcm_16bit_2ch;
+        fmt.new_decoder = new_decoder_pcm_16bit_2ch;
+        add_(fmt);
     }
+    {
+        Format fmt;
+        fmt.payload_type = PayloadType_L16_Mono;
+        fmt.flags = packet::Packet::FlagAudio;
+        fmt.sample_rate = 44100;
+        fmt.channel_mask = 0x1;
+        fmt.get_num_samples = PCM_16bit_1ch.samples_from_payload_size;
+        fmt.new_encoder = new_encoder_pcm_16bit_1ch;
+        fmt.new_decoder = new_decoder_pcm_16bit_1ch;
+        add_(fmt);
+    }
+}
+
+const Format* FormatMap::format(unsigned int pt) const {
+    for (size_t n = 0; n < n_formats_; n++) {
+        if ((unsigned int)formats_[n].payload_type == pt) {
+            return &formats_[n];
+        }
+    }
+
+    return NULL;
+}
+
+void FormatMap::add_(const Format& fmt) {
+    roc_panic_if(n_formats_ == MaxFormats);
+    formats_[n_formats_++] = fmt;
 }
 
 } // namespace rtp

--- a/src/modules/roc_rtp/format_map.h
+++ b/src/modules/roc_rtp/format_map.h
@@ -21,11 +21,21 @@ namespace rtp {
 //! RTP payload format map.
 class FormatMap : public core::NonCopyable<> {
 public:
+    FormatMap();
+
     //! Get format by payload type.
     //! @returns
     //!  pointer to the format structure or null if there is no format
     //!  registered for this payload type.
     const Format* format(unsigned int pt) const;
+
+private:
+    enum { MaxFormats = 2 };
+
+    Format formats_[MaxFormats];
+    size_t n_formats_;
+
+    void add_(const Format& fmt);
 };
 
 } // namespace rtp

--- a/src/modules/roc_rtp/parser.cpp
+++ b/src/modules/roc_rtp/parser.cpp
@@ -100,7 +100,7 @@ bool Parser::parse(packet::Packet& packet, const core::Slice<uint8_t>& buffer) {
 
     if (const Format* format = format_map_.format(header.payload_type())) {
         packet.add_flags(format->flags);
-        rtp.duration = format->duration(rtp);
+        rtp.duration = (packet::timestamp_t)format->get_num_samples(rtp.payload.size());
     }
 
     if (inner_parser_) {

--- a/src/modules/roc_rtp/pcm_decoder.cpp
+++ b/src/modules/roc_rtp/pcm_decoder.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_rtp/pcm_decoder.h"
+#include "roc_core/panic.h"
+
+namespace roc {
+namespace rtp {
+
+PCMDecoder::PCMDecoder(const PCMFuncs& funcs, const Format&)
+    : funcs_(funcs) {
+}
+
+size_t PCMDecoder::read_samples(const packet::Packet& packet,
+                                size_t offset,
+                                audio::sample_t* samples,
+                                size_t n_samples,
+                                packet::channel_mask_t channels) {
+    const packet::RTP* rtp = packet.rtp();
+    if (!rtp) {
+        roc_panic("unexpected non-rtp packet");
+    }
+
+    return funcs_.decode_samples(rtp->payload.data(), rtp->payload.size(), offset,
+                                 samples, n_samples, channels);
+}
+
+} // namespace rtp
+} // namespace roc

--- a/src/modules/roc_rtp/pcm_decoder.cpp
+++ b/src/modules/roc_rtp/pcm_decoder.cpp
@@ -13,21 +13,76 @@ namespace roc {
 namespace rtp {
 
 PCMDecoder::PCMDecoder(const PCMFuncs& funcs, const Format&)
-    : funcs_(funcs) {
+    : funcs_(funcs)
+    , stream_pos_(0)
+    , packet_pos_(0)
+    , packet_rem_(0) {
 }
 
-size_t PCMDecoder::read_samples(const packet::Packet& packet,
-                                size_t offset,
-                                audio::sample_t* samples,
-                                size_t n_samples,
-                                packet::channel_mask_t channels) {
-    const packet::RTP* rtp = packet.rtp();
+void PCMDecoder::set(const packet::PacketPtr& packet) {
+    roc_panic_if(!packet);
+
+    packet::RTP* rtp = packet->rtp();
     if (!rtp) {
-        roc_panic("unexpected non-rtp packet");
+        roc_panic("pcm decoder: unexpected non-rtp packet");
     }
 
-    return funcs_.decode_samples(rtp->payload.data(), rtp->payload.size(), offset,
-                                 samples, n_samples, channels);
+    stream_pos_ = rtp->timestamp;
+    packet_pos_ = 0;
+    packet_rem_ = rtp->duration;
+
+    packet_ = packet;
+}
+
+packet::timestamp_t PCMDecoder::timestamp() const {
+    if (!packet_) {
+        roc_panic("pcm decoder: position() should be called after set()");
+    }
+
+    return stream_pos_;
+}
+
+packet::timestamp_t PCMDecoder::remaining() const {
+    if (!packet_) {
+        roc_panic("pcm decoder: remaining() should be called after set()");
+    }
+
+    return packet_rem_;
+}
+
+size_t PCMDecoder::read(audio::sample_t* samples,
+                        size_t n_samples,
+                        packet::channel_mask_t channels) {
+    if (!packet_) {
+        roc_panic("pcm decoder: read() should be called after set()");
+    }
+
+    if (n_samples > (size_t)packet_rem_) {
+        n_samples = (size_t)packet_rem_;
+    }
+
+    packet::RTP& rtp = *packet_->rtp();
+
+    const size_t rd_samples =
+        funcs_.decode_samples(rtp.payload.data(), rtp.payload.size(), packet_pos_,
+                              samples, n_samples, channels);
+
+    advance(rd_samples);
+
+    return rd_samples;
+}
+
+void PCMDecoder::advance(size_t n_samples) {
+    packet::timestamp_t ns = (packet::timestamp_t)n_samples;
+
+    stream_pos_ += ns;
+    packet_pos_ += ns;
+
+    if (ns > packet_rem_) {
+        ns = packet_rem_;
+    }
+
+    packet_rem_ -= ns;
 }
 
 } // namespace rtp

--- a/src/modules/roc_rtp/pcm_decoder.h
+++ b/src/modules/roc_rtp/pcm_decoder.h
@@ -26,15 +26,31 @@ public:
     //! Initialize.
     PCMDecoder(const PCMFuncs& funcs, const Format& format);
 
-    //! Read samples from packet.
-    virtual size_t read_samples(const packet::Packet& packet,
-                                size_t offset,
-                                audio::sample_t* samples,
-                                size_t n_samples,
-                                packet::channel_mask_t channels);
+    //! Start decoding a new packet.
+    virtual void set(const packet::PacketPtr& packet);
+
+    //! Get current stream position.
+    virtual packet::timestamp_t timestamp() const;
+
+    //! Get number of samples remaining in the current packet.
+    virtual packet::timestamp_t remaining() const;
+
+    //! Decode samples.
+    virtual size_t
+    read(audio::sample_t* samples, size_t n_samples, packet::channel_mask_t channels);
+
+    //! Advance the stream position.
+    virtual void advance(size_t n_samples);
 
 private:
     const PCMFuncs& funcs_;
+
+    packet::timestamp_t stream_pos_;
+
+    packet::timestamp_t packet_pos_;
+    packet::timestamp_t packet_rem_;
+
+    packet::PacketPtr packet_;
 };
 
 } // namespace rtp

--- a/src/modules/roc_rtp/pcm_decoder.h
+++ b/src/modules/roc_rtp/pcm_decoder.h
@@ -13,35 +13,28 @@
 #define ROC_RTP_PCM_DECODER_H_
 
 #include "roc_audio/idecoder.h"
-#include "roc_core/iallocator.h"
 #include "roc_core/panic.h"
-#include "roc_rtp/pcm_helpers.h"
+#include "roc_rtp/format.h"
+#include "roc_rtp/pcm_funcs.h"
 
 namespace roc {
 namespace rtp {
 
 //! PCM decoder.
-template <class Sample, size_t NumCh>
 class PCMDecoder : public audio::IDecoder, public core::NonCopyable<> {
 public:
-    //! Create decoder.
-    static audio::IDecoder* create(core::IAllocator& allocator) {
-        return new (allocator) PCMDecoder;
-    }
+    //! Initialize.
+    PCMDecoder(const PCMFuncs& funcs, const Format& format);
 
     //! Read samples from packet.
     virtual size_t read_samples(const packet::Packet& packet,
                                 size_t offset,
                                 audio::sample_t* samples,
                                 size_t n_samples,
-                                packet::channel_mask_t channels) {
-        const packet::RTP* rtp = packet.rtp();
-        if (!rtp) {
-            roc_panic("unexpected non-rtp packet");
-        }
-        return pcm_read<Sample, NumCh>(rtp->payload.data(), rtp->payload.size(), offset,
-                                       samples, n_samples, channels);
-    }
+                                packet::channel_mask_t channels);
+
+private:
+    const PCMFuncs& funcs_;
 };
 
 } // namespace rtp

--- a/src/modules/roc_rtp/pcm_encoder.cpp
+++ b/src/modules/roc_rtp/pcm_encoder.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_rtp/pcm_encoder.h"
+#include "roc_core/panic.h"
+#include "roc_core/random.h"
+#include "roc_rtp/headers.h"
+
+namespace roc {
+namespace rtp {
+
+PCMEncoder::PCMEncoder(const PCMFuncs& funcs, const Format& format)
+    : funcs_(funcs)
+    , packet_pos_(0)
+    , sample_rate_(format.sample_rate)
+    , source_((packet::source_t)core::random(packet::source_t(-1)))
+    , payload_type_(format.payload_type)
+    , seqnum_((packet::seqnum_t)core::random(packet::seqnum_t(-1)))
+    , timestamp_((packet::timestamp_t)core::random(packet::timestamp_t(-1))) {
+}
+
+size_t PCMEncoder::packet_size(core::nanoseconds_t duration) const {
+    const packet::timestamp_diff_t num_samples =
+        packet::timestamp_from_ns(duration, sample_rate_);
+    if (num_samples < 0) {
+        return 0;
+    }
+    return sizeof(Header) + funcs_.payload_size_from_samples((size_t)num_samples);
+}
+
+size_t PCMEncoder::payload_size(size_t num_samples) const {
+    return funcs_.payload_size_from_samples(num_samples);
+}
+
+void PCMEncoder::begin(const packet::PacketPtr& packet) {
+    if (packet_) {
+        roc_panic("pcm encoder: unpaired begin/end");
+    }
+
+    packet::RTP* rtp = packet->rtp();
+    if (!rtp) {
+        roc_panic("pcm encoder: unexpected non-rtp packet");
+    }
+
+    rtp->source = source_;
+    rtp->seqnum = seqnum_;
+    rtp->timestamp = timestamp_;
+    rtp->payload_type = payload_type_;
+
+    packet_ = packet;
+}
+
+size_t PCMEncoder::write(const audio::sample_t* samples,
+                         size_t n_samples,
+                         packet::channel_mask_t channels) {
+    if (!packet_) {
+        roc_panic("pcm encoder: write() should be called only between begin() and end()");
+    }
+
+    packet::RTP& rtp = *packet_->rtp();
+
+    const size_t wr_samples =
+        funcs_.encode_samples(rtp.payload.data(), rtp.payload.size(), packet_pos_,
+                              samples, n_samples, channels);
+
+    packet_pos_ += wr_samples;
+    return wr_samples;
+}
+
+void PCMEncoder::end() {
+    if (!packet_) {
+        roc_panic("pcm encoder: unpaired begin/end");
+    }
+
+    packet::RTP& rtp = *packet_->rtp();
+
+    rtp.duration = (packet::timestamp_t)packet_pos_;
+
+    // TODO: zeroize and setup padding if necessary
+
+    seqnum_++;
+    timestamp_ += (packet::timestamp_t)packet_pos_;
+
+    packet_pos_ = 0;
+    packet_ = NULL;
+}
+
+} // namespace rtp
+} // namespace roc

--- a/src/modules/roc_rtp/pcm_funcs.cpp
+++ b/src/modules/roc_rtp/pcm_funcs.cpp
@@ -6,69 +6,45 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-//! @file roc_rtp/pcm_helpers.h
-//! @brief PCM helpers.
-
-#ifndef ROC_RTP_PCM_HELPERS_H_
-#define ROC_RTP_PCM_HELPERS_H_
-
-#include "roc_audio/units.h"
+#include "roc_rtp/pcm_funcs.h"
 #include "roc_core/endian.h"
 #include "roc_core/stddefs.h"
-#include "roc_packet/units.h"
-#include "roc_rtp/headers.h"
 
 namespace roc {
 namespace rtp {
 
-//! Calculate packet duration.
+namespace {
+
 template <class Sample, size_t NumCh>
-packet::timestamp_t pcm_duration_from_header(const packet::RTP& rtp) {
-    return packet::timestamp_t(rtp.payload.size() / NumCh / sizeof(Sample));
+size_t pcm_samples_from_payload_size(size_t payload_size) {
+    return payload_size / NumCh / sizeof(Sample);
 }
 
-//! Calculate payload size.
 template <class Sample, size_t NumCh>
 size_t pcm_payload_size_from_samples(size_t num_samples) {
     return num_samples * NumCh * sizeof(Sample);
 }
 
-//! Calculate packet size.
-template <class Sample, size_t NumCh, size_t SampleRate>
-size_t pcm_packet_size_from_duration(core::nanoseconds_t duration) {
-    const packet::timestamp_diff_t num_samples =
-        packet::timestamp_from_ns(duration, SampleRate);
-    if (num_samples < 0) {
-        return 0;
-    }
-    return sizeof(Header)
-        + pcm_payload_size_from_samples<Sample, NumCh>((size_t)num_samples);
-}
+template <class T> T pcm_encode_one_sample(audio::sample_t);
 
-//! Encode single sample.
-template <class T> T pcm_pack(audio::sample_t);
-
-//! Encode single sample (int16_t).
-template <> int16_t inline pcm_pack(float s) {
+template <> int16_t inline pcm_encode_one_sample(float s) {
     s *= 32768.0f;
     s = std::min(s, +32767.0f);
     s = std::max(s, -32768.0f);
     return (int16_t)core::hton16((uint16_t)(int16_t)s);
 }
 
-//! Decode single sample (int16_t).
-inline float pcm_unpack(int16_t s) {
+inline float pcm_decode_one_sample(int16_t s) {
     return float((int16_t)core::ntoh16((uint16_t)s)) / 32768.0f;
 }
 
-//! Decode multiple samples.
 template <class Sample, size_t NumCh>
-size_t pcm_write(void* out_data,
-                 size_t out_size,
-                 size_t out_offset,
-                 const audio::sample_t* in_samples,
-                 size_t in_n_samples,
-                 packet::channel_mask_t in_chan_mask) {
+size_t pcm_encode_samples(void* out_data,
+                          size_t out_size,
+                          size_t out_offset,
+                          const audio::sample_t* in_samples,
+                          size_t in_n_samples,
+                          packet::channel_mask_t in_chan_mask) {
     const packet::channel_mask_t out_chan_mask = packet::channel_mask_t(1 << NumCh) - 1;
     const packet::channel_mask_t inout_chan_mask = in_chan_mask | out_chan_mask;
 
@@ -88,12 +64,13 @@ size_t pcm_write(void* out_data,
         for (packet::channel_mask_t ch = 1; ch <= inout_chan_mask && ch != 0; ch <<= 1) {
             if (in_chan_mask & ch) {
                 if (out_chan_mask & ch) {
-                    *out_samples = pcm_pack<Sample>(*in_samples);
+                    *out_samples++ = pcm_encode_one_sample<Sample>(*in_samples);
                 }
                 in_samples++;
-            }
-            if (out_chan_mask & ch) {
-                out_samples++;
+            } else {
+                if (out_chan_mask & ch) {
+                    *out_samples++ = 0;
+                }
             }
         }
     }
@@ -101,14 +78,13 @@ size_t pcm_write(void* out_data,
     return in_n_samples;
 }
 
-//! Decode multiple samples.
 template <class Sample, size_t NumCh>
-size_t pcm_read(const void* in_data,
-                size_t in_size,
-                size_t in_offset,
-                audio::sample_t* out_samples,
-                size_t out_n_samples,
-                packet::channel_mask_t out_chan_mask) {
+size_t pcm_decode_samples(const void* in_data,
+                          size_t in_size,
+                          size_t in_offset,
+                          audio::sample_t* out_samples,
+                          size_t out_n_samples,
+                          packet::channel_mask_t out_chan_mask) {
     const packet::channel_mask_t in_chan_mask = packet::channel_mask_t(1 << NumCh) - 1;
     const packet::channel_mask_t inout_chan_mask = in_chan_mask | out_chan_mask;
 
@@ -128,7 +104,7 @@ size_t pcm_read(const void* in_data,
         for (packet::channel_mask_t ch = 1; ch <= inout_chan_mask && ch != 0; ch <<= 1) {
             audio::sample_t s = 0;
             if (in_chan_mask & ch) {
-                s = pcm_unpack(*in_samples++);
+                s = pcm_decode_one_sample(*in_samples++);
             }
             if (out_chan_mask & ch) {
                 *out_samples++ = s;
@@ -139,7 +115,21 @@ size_t pcm_read(const void* in_data,
     return out_n_samples;
 }
 
+} // namespace
+
+const PCMFuncs PCM_16bit_2ch = {
+    pcm_samples_from_payload_size<int16_t, 2>,
+    pcm_payload_size_from_samples<int16_t, 2>,
+    pcm_encode_samples<int16_t, 2>,
+    pcm_decode_samples<int16_t, 2>,
+};
+
+const PCMFuncs PCM_16bit_1ch = {
+    pcm_samples_from_payload_size<int16_t, 1>,
+    pcm_payload_size_from_samples<int16_t, 1>,
+    pcm_encode_samples<int16_t, 1>,
+    pcm_decode_samples<int16_t, 1>,
+};
+
 } // namespace rtp
 } // namespace roc
-
-#endif // ROC_RTP_PCM_HELPERS_H_

--- a/src/modules/roc_rtp/pcm_funcs.h
+++ b/src/modules/roc_rtp/pcm_funcs.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_rtp/pcm_funcs.h
+//! @brief RTP PCM functions.
+
+#ifndef ROC_RTP_PCM_FUNCS_H_
+#define ROC_RTP_PCM_FUNCS_H_
+
+#include "roc_audio/units.h"
+#include "roc_core/stddefs.h"
+#include "roc_packet/rtp.h"
+#include "roc_packet/units.h"
+
+namespace roc {
+namespace rtp {
+
+//! PCM function table.
+struct PCMFuncs {
+    //! Get number of samples per channel from payload size in bytes.
+    size_t (*samples_from_payload_size)(size_t payload_size);
+
+    //! Get payload size in bytes from number of samples per channel.
+    size_t (*payload_size_from_samples)(size_t num_samples);
+
+    //! Encode samples.
+    size_t (*encode_samples)(void* out_data,
+                             size_t out_size,
+                             size_t out_offset,
+                             const audio::sample_t* in_samples,
+                             size_t in_n_samples,
+                             packet::channel_mask_t in_chan_mask);
+
+    //! Decode samples.
+    size_t (*decode_samples)(const void* in_data,
+                             size_t in_size,
+                             size_t in_offset,
+                             audio::sample_t* out_samples,
+                             size_t out_n_samples,
+                             packet::channel_mask_t out_chan_mask);
+};
+
+//! PCM functions for 16-bit 2-channel audio.
+extern const PCMFuncs PCM_16bit_2ch;
+
+//! PCM functions for 16-bit 1-channel audio.
+extern const PCMFuncs PCM_16bit_1ch;
+
+} // namespace rtp
+} // namespace roc
+
+#endif // ROC_RTP_PCM_FUNCS_H_

--- a/src/tests/roc_pipeline/test_receiver.cpp
+++ b/src/tests/roc_pipeline/test_receiver.cpp
@@ -14,7 +14,7 @@
 #include "roc_pipeline/receiver.h"
 #include "roc_rtp/composer.h"
 #include "roc_rtp/format_map.h"
-#include "roc_rtp/pcm_encoder.h"
+#include "roc_rtp/pcm_funcs.h"
 
 #include "test_frame_reader.h"
 #include "test_packet_writer.h"
@@ -53,7 +53,8 @@ packet::PacketPool packet_pool(allocator, true);
 
 rtp::FormatMap format_map;
 rtp::Composer rtp_composer(NULL);
-rtp::PCMEncoder<int16_t, NumCh> pcm_encoder;
+
+const rtp::PCMFuncs& pcm_funcs = rtp::PCM_16bit_2ch;
 
 } // namespace
 
@@ -125,7 +126,7 @@ TEST(receiver, no_ports) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -150,7 +151,7 @@ TEST(receiver, one_session) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -177,7 +178,7 @@ TEST(receiver, one_session_long_run) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -204,7 +205,7 @@ TEST(receiver, initial_latency) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     for (size_t np = 0; np < Latency / SamplesPerPacket - 1; np++) {
@@ -237,7 +238,7 @@ TEST(receiver, initial_latency_timeout) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(1, SamplesPerPacket, ChMask);
@@ -264,7 +265,7 @@ TEST(receiver, timeout) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -291,7 +292,7 @@ TEST(receiver, initial_trim) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency * 3 / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -318,10 +319,10 @@ TEST(receiver, two_sessions_synchronous) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer1(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer1(receiver, rtp_composer, pcm_funcs, packet_pool,
                                 byte_buffer_pool, PayloadType, src1, port1.address);
 
-    PacketWriter packet_writer2(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer2(receiver, rtp_composer, pcm_funcs, packet_pool,
                                 byte_buffer_pool, PayloadType, src2, port1.address);
 
     for (size_t np = 0; np < Latency / SamplesPerPacket; np++) {
@@ -350,7 +351,7 @@ TEST(receiver, two_sessions_overlapping) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer1(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer1(receiver, rtp_composer, pcm_funcs, packet_pool,
                                 byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer1.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -365,7 +366,7 @@ TEST(receiver, two_sessions_overlapping) {
         packet_writer1.write_packets(1, SamplesPerPacket, ChMask);
     }
 
-    PacketWriter packet_writer2(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer2(receiver, rtp_composer, pcm_funcs, packet_pool,
                                 byte_buffer_pool, PayloadType, src2, port1.address);
 
     packet_writer2.set_offset(packet_writer1.offset() - Latency * NumCh);
@@ -394,10 +395,10 @@ TEST(receiver, two_sessions_two_ports) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer1(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer1(receiver, rtp_composer, pcm_funcs, packet_pool,
                                 byte_buffer_pool, PayloadType, src1, port1.address);
 
-    PacketWriter packet_writer2(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer2(receiver, rtp_composer, pcm_funcs, packet_pool,
                                 byte_buffer_pool, PayloadType, src2, port2.address);
 
     for (size_t np = 0; np < Latency / SamplesPerPacket; np++) {
@@ -428,10 +429,10 @@ TEST(receiver, two_sessions_same_address_same_stream) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer1(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer1(receiver, rtp_composer, pcm_funcs, packet_pool,
                                 byte_buffer_pool, PayloadType, src1, port1.address);
 
-    PacketWriter packet_writer2(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer2(receiver, rtp_composer, pcm_funcs, packet_pool,
                                 byte_buffer_pool, PayloadType, src1, port2.address);
 
     packet_writer1.set_source(11);
@@ -467,10 +468,10 @@ TEST(receiver, two_sessions_same_address_different_streams) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer1(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer1(receiver, rtp_composer, pcm_funcs, packet_pool,
                                 byte_buffer_pool, PayloadType, src1, port1.address);
 
-    PacketWriter packet_writer2(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer2(receiver, rtp_composer, pcm_funcs, packet_pool,
                                 byte_buffer_pool, PayloadType, src1, port2.address);
 
     packet_writer1.set_source(11);
@@ -506,7 +507,7 @@ TEST(receiver, seqnum_overflow) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.set_seqnum(packet::seqnum_t(-1) - ManyPackets / 2);
@@ -531,7 +532,7 @@ TEST(receiver, seqnum_small_jump) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -562,7 +563,7 @@ TEST(receiver, seqnum_large_jump) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -599,7 +600,7 @@ TEST(receiver, seqnum_reorder) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     size_t pos = 0;
@@ -631,7 +632,7 @@ TEST(receiver, seqnum_late) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -679,7 +680,7 @@ TEST(receiver, timestamp_overflow) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.set_timestamp(packet::timestamp_t(-1)
@@ -706,7 +707,7 @@ TEST(receiver, timestamp_small_jump) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -745,7 +746,7 @@ TEST(receiver, timestamp_large_jump) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -776,7 +777,7 @@ TEST(receiver, timestamp_overlap) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -801,7 +802,7 @@ TEST(receiver, timestamp_reorder) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -848,7 +849,7 @@ TEST(receiver, timestamp_late) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -905,7 +906,7 @@ TEST(receiver, packet_size_small) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerSmallPacket, SamplesPerSmallPacket,
@@ -934,7 +935,7 @@ TEST(receiver, packet_size_large) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerLargePacket, SamplesPerLargePacket,
@@ -969,7 +970,7 @@ TEST(receiver, packet_size_variable) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     size_t available = 0;
@@ -995,7 +996,7 @@ TEST(receiver, corrupted_packets_new_session) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.set_corrupt(true);
@@ -1022,7 +1023,7 @@ TEST(receiver, corrupted_packets_existing_session) {
 
     FrameReader frame_reader(receiver, sample_buffer_pool);
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     packet_writer.write_packets(Latency / SamplesPerPacket, SamplesPerPacket, ChMask);
@@ -1068,7 +1069,7 @@ TEST(receiver, status) {
     CHECK(receiver.valid());
     CHECK(receiver.add_port(port1));
 
-    PacketWriter packet_writer(receiver, rtp_composer, pcm_encoder, packet_pool,
+    PacketWriter packet_writer(receiver, rtp_composer, pcm_funcs, packet_pool,
                                byte_buffer_pool, PayloadType, src1, port1.address);
 
     core::Slice<audio::sample_t> samples(

--- a/src/tests/roc_pipeline/test_sender.cpp
+++ b/src/tests/roc_pipeline/test_sender.cpp
@@ -15,7 +15,7 @@
 #include "roc_pipeline/sender.h"
 #include "roc_rtp/format_map.h"
 #include "roc_rtp/parser.h"
-#include "roc_rtp/pcm_decoder.h"
+#include "roc_rtp/pcm_funcs.h"
 
 #include "test_frame_writer.h"
 #include "test_packet_reader.h"
@@ -48,7 +48,8 @@ packet::PacketPool packet_pool(allocator, true);
 
 rtp::FormatMap format_map;
 rtp::Parser rtp_parser(format_map, NULL);
-rtp::PCMDecoder<int16_t, NumCh> pcm_decoder;
+
+const rtp::PCMFuncs& pcm_funcs = rtp::PCM_16bit_2ch;
 
 } // namespace
 
@@ -86,7 +87,7 @@ TEST(sender, write) {
         frame_writer.write_samples(SamplesPerFrame * NumCh);
     }
 
-    PacketReader packet_reader(queue, rtp_parser, pcm_decoder, packet_pool, PayloadType,
+    PacketReader packet_reader(queue, rtp_parser, pcm_funcs, packet_pool, PayloadType,
                                source_port.address);
 
     for (size_t np = 0; np < ManyFrames / FramesPerPacket; np++) {
@@ -116,7 +117,7 @@ TEST(sender, frame_size_small) {
         frame_writer.write_samples(SamplesPerSmallFrame * NumCh);
     }
 
-    PacketReader packet_reader(queue, rtp_parser, pcm_decoder, packet_pool, PayloadType,
+    PacketReader packet_reader(queue, rtp_parser, pcm_funcs, packet_pool, PayloadType,
                                source_port.address);
 
     for (size_t np = 0; np < ManySmallFrames / SmallFramesPerPacket; np++) {
@@ -146,7 +147,7 @@ TEST(sender, frame_size_large) {
         frame_writer.write_samples(SamplesPerLargeFrame * NumCh);
     }
 
-    PacketReader packet_reader(queue, rtp_parser, pcm_decoder, packet_pool, PayloadType,
+    PacketReader packet_reader(queue, rtp_parser, pcm_funcs, packet_pool, PayloadType,
                                source_port.address);
 
     for (size_t np = 0; np < ManyLargeFrames * PacketsPerLargeFrame; np++) {

--- a/src/tests/roc_rtp/test_composer_parser.cpp
+++ b/src/tests/roc_rtp/test_composer_parser.cpp
@@ -35,7 +35,7 @@ packet::PacketPool packet_pool(allocator, true);
 
 } // namespace
 
-TEST_GROUP(packets) {
+TEST_GROUP(composer_parser) {
     core::Slice<uint8_t> new_buffer(const uint8_t* data, size_t datasz) {
         core::Slice<uint8_t> buf = new (buffer_pool) core::Buffer<uint8_t>(buffer_pool);
         if (data) {
@@ -228,15 +228,15 @@ TEST_GROUP(packets) {
     }
 };
 
-TEST(packets, l16_2ch_320s) {
+TEST(composer_parser, l16_2ch_320s) {
     check(rtp_l16_2ch_320s, PCM_16bit_2ch, true);
 }
 
-TEST(packets, l16_1ch_10s_12ext) {
+TEST(composer_parser, l16_1ch_10s_12ext) {
     check(rtp_l16_1ch_10s_12ext, PCM_16bit_1ch, false);
 }
 
-TEST(packets, l16_1ch_10s_4pad_2csrc_12ext_marker) {
+TEST(composer_parser, l16_1ch_10s_4pad_2csrc_12ext_marker) {
     check(rtp_l16_1ch_10s_4pad_2csrc_12ext_marker, PCM_16bit_1ch, false);
 }
 

--- a/src/tests/roc_rtp/test_encoder_decoder.cpp
+++ b/src/tests/roc_rtp/test_encoder_decoder.cpp
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <CppUTest/TestHarness.h>
+
+#include "roc_core/buffer_pool.h"
+#include "roc_core/heap_allocator.h"
+#include "roc_core/unique_ptr.h"
+#include "roc_packet/packet_pool.h"
+#include "roc_rtp/composer.h"
+#include "roc_rtp/format_map.h"
+#include "roc_rtp/pcm_decoder.h"
+#include "roc_rtp/pcm_encoder.h"
+#include "roc_rtp/pcm_funcs.h"
+
+namespace roc {
+namespace rtp {
+
+namespace {
+
+enum {
+    Test_PCM_16bit_1ch,
+    Test_PCM_16bit_2ch,
+
+    Test_NumCodecs
+};
+
+packet::channel_mask_t Test_codec_channels[Test_NumCodecs] = {
+    0x1,
+    0x3
+};
+
+unsigned int Test_codec_pts[Test_NumCodecs] = {
+    11,
+    10
+};
+
+enum { MaxChans = 8, MaxBufSize = 1000 };
+
+const double Epsilon = 0.00001;
+
+core::HeapAllocator allocator;
+core::BufferPool<uint8_t> byte_buffer_pool(allocator, MaxBufSize, true);
+packet::PacketPool packet_pool(allocator, true);
+
+Composer rtp_composer(NULL);
+FormatMap format_map;
+
+audio::sample_t nth_sample(uint8_t n) {
+    return audio::sample_t(n) / audio::sample_t(1 << 8);
+}
+
+} // namespace
+
+TEST_GROUP(encoder) {
+    const Format& get_format(unsigned int pt) {
+        const Format* fmt = format_map.format(pt);
+        CHECK(fmt);
+        return *fmt;
+    }
+
+    audio::IEncoder* new_encoder(size_t id) {
+        switch (id) {
+        case Test_PCM_16bit_1ch:
+            return new (allocator)
+                PCMEncoder(PCM_16bit_1ch, get_format(PayloadType_L16_Mono));
+
+        case Test_PCM_16bit_2ch:
+            return new (allocator)
+                PCMEncoder(PCM_16bit_2ch, get_format(PayloadType_L16_Stereo));
+
+        default:
+            FAIL("bad codec id");
+        }
+
+        return NULL;
+    }
+
+    audio::IDecoder* new_decoder(size_t id) {
+        switch (id) {
+        case Test_PCM_16bit_1ch:
+            return new (allocator)
+                PCMDecoder(PCM_16bit_1ch, get_format(PayloadType_L16_Mono));
+
+        case Test_PCM_16bit_2ch:
+            return new (allocator)
+                PCMDecoder(PCM_16bit_2ch, get_format(PayloadType_L16_Stereo));
+
+        default:
+            FAIL("bad codec id");
+        }
+
+        return NULL;
+    }
+
+    packet::PacketPtr new_packet(size_t payload_size) {
+        packet::PacketPtr pp = new(packet_pool) packet::Packet(packet_pool);
+        CHECK(pp);
+
+        core::Slice<uint8_t> bp =
+            new (byte_buffer_pool) core::Buffer<uint8_t>(byte_buffer_pool);
+        CHECK(bp);
+
+        CHECK(rtp_composer.prepare(*pp, bp, payload_size));
+
+        pp->set_data(bp);
+
+        return pp;
+    }
+
+    size_t fill_samples(audio::sample_t* samples,
+                        size_t pos,
+                        size_t n_samples,
+                        packet::channel_mask_t ch_mask) {
+        const size_t n_chans = packet::num_channels(ch_mask);
+
+        for (size_t i = 0; i < n_samples; i++) {
+            for (size_t j = 0; j < n_chans; j++) {
+                *samples++ = nth_sample(uint8_t(pos++));
+            }
+        }
+
+        return pos;
+    }
+
+    size_t check_samples(const audio::sample_t* samples,
+                         size_t pos,
+                         size_t n_samples,
+                         packet::channel_mask_t ch_mask) {
+        const size_t n_chans = packet::num_channels(ch_mask);
+
+        for (size_t i = 0; i < n_samples; i++) {
+            for (size_t j = 0; j < n_chans; j++) {
+                audio::sample_t actual = *samples++;
+                audio::sample_t expected = nth_sample(uint8_t(pos++));
+
+                DOUBLES_EQUAL(expected, actual, Epsilon);
+            }
+        }
+
+        return pos;
+    }
+
+    size_t check_zeros(const audio::sample_t* samples, size_t pos, size_t n_samples) {
+        for (size_t i = 0; i < n_samples; i++) {
+            audio::sample_t actual = *samples++;
+            DOUBLES_EQUAL(0.0, actual, Epsilon);
+            pos++;
+        }
+
+        return pos;
+    }
+};
+
+TEST(encoder, one_packet) {
+    enum { SamplesPerPacket = 177 };
+
+    for (size_t n_codec = 0; n_codec < Test_NumCodecs; n_codec++) {
+        core::UniquePtr<audio::IEncoder> encoder(new_encoder(n_codec), allocator);
+        CHECK(encoder);
+
+        core::UniquePtr<audio::IDecoder> decoder(new_decoder(n_codec), allocator);
+        CHECK(decoder);
+
+        packet::PacketPtr pp = new_packet(encoder->payload_size(SamplesPerPacket));
+
+        encoder->begin(pp);
+
+        audio::sample_t encoder_samples[SamplesPerPacket * MaxChans] = {};
+        fill_samples(encoder_samples, 0, SamplesPerPacket, Test_codec_channels[n_codec]);
+
+        UNSIGNED_LONGS_EQUAL(SamplesPerPacket,
+                             encoder->write(encoder_samples, SamplesPerPacket,
+                                            Test_codec_channels[n_codec]));
+
+        encoder->end();
+
+        UNSIGNED_LONGS_EQUAL(Test_codec_pts[n_codec], pp->rtp()->payload_type);
+
+        audio::sample_t decoder_samples[SamplesPerPacket * MaxChans];
+
+        UNSIGNED_LONGS_EQUAL(SamplesPerPacket,
+                             decoder->read_samples(*pp, 0, decoder_samples,
+                                                   SamplesPerPacket,
+                                                   Test_codec_channels[n_codec]));
+
+        check_samples(decoder_samples, 0, SamplesPerPacket, Test_codec_channels[n_codec]);
+    }
+}
+
+TEST(encoder, multiple_packets) {
+    enum { NumPackets = 10, SamplesPerPacket = 177 };
+
+    for (size_t n_codec = 0; n_codec < Test_NumCodecs; n_codec++) {
+        core::UniquePtr<audio::IEncoder> encoder(new_encoder(n_codec), allocator);
+        CHECK(encoder);
+
+        core::UniquePtr<audio::IDecoder> decoder(new_decoder(n_codec), allocator);
+        CHECK(decoder);
+
+        packet::source_t src = 0;
+        packet::seqnum_t sn = 0;
+        packet::timestamp_t ts = 0;
+
+        size_t encoder_pos = 0;
+        size_t decoder_pos = 0;
+
+        for (size_t n = 0; n < NumPackets; n++) {
+            packet::PacketPtr pp = new_packet(encoder->payload_size(SamplesPerPacket));
+
+            encoder->begin(pp);
+
+
+            audio::sample_t encoder_samples[SamplesPerPacket * MaxChans] = {};
+            encoder_pos = fill_samples(encoder_samples, encoder_pos, SamplesPerPacket,
+                                       Test_codec_channels[n_codec]);
+
+            UNSIGNED_LONGS_EQUAL(SamplesPerPacket,
+                                 encoder->write(encoder_samples, SamplesPerPacket,
+                                                Test_codec_channels[n_codec]));
+
+            encoder->end();
+
+            if (n == 0) {
+                src = pp->rtp()->source;
+                sn = pp->rtp()->seqnum;
+                ts = pp->rtp()->timestamp;
+            }
+
+            UNSIGNED_LONGS_EQUAL(Test_codec_pts[n_codec], pp->rtp()->payload_type);
+            UNSIGNED_LONGS_EQUAL(src, pp->rtp()->source);
+            UNSIGNED_LONGS_EQUAL(sn, pp->rtp()->seqnum);
+            UNSIGNED_LONGS_EQUAL(ts, pp->rtp()->timestamp);
+
+            sn++;
+            ts += SamplesPerPacket;
+
+
+            audio::sample_t decoder_samples[SamplesPerPacket * MaxChans];
+
+            UNSIGNED_LONGS_EQUAL(SamplesPerPacket,
+                                 decoder->read_samples(*pp, 0, decoder_samples,
+                                                       SamplesPerPacket,
+                                                       Test_codec_channels[n_codec]));
+
+            decoder_pos = check_samples(decoder_samples, decoder_pos, SamplesPerPacket,
+                                        Test_codec_channels[n_codec]);
+
+            UNSIGNED_LONGS_EQUAL(encoder_pos, decoder_pos);
+        }
+    }
+}
+
+TEST(encoder, write_incrementally) {
+    enum { FirstPart = 33, SecondPart = 44, SamplesPerPacket = FirstPart + SecondPart };
+
+    for (size_t n_codec = 0; n_codec < Test_NumCodecs; n_codec++) {
+        core::UniquePtr<audio::IEncoder> encoder(new_encoder(n_codec), allocator);
+        CHECK(encoder);
+
+        core::UniquePtr<audio::IDecoder> decoder(new_decoder(n_codec), allocator);
+        CHECK(decoder);
+
+        packet::PacketPtr pp = new_packet(encoder->payload_size(SamplesPerPacket));
+
+        encoder->begin(pp);
+
+        audio::sample_t encoder_samples[SamplesPerPacket * MaxChans] = {};
+        fill_samples(encoder_samples, 0, SamplesPerPacket, Test_codec_channels[n_codec]);
+
+        UNSIGNED_LONGS_EQUAL(
+            FirstPart,
+            encoder->write(encoder_samples, FirstPart, Test_codec_channels[n_codec]));
+
+        UNSIGNED_LONGS_EQUAL(
+            SecondPart,
+            encoder->write(encoder_samples
+                               + FirstPart
+                                   * packet::num_channels(Test_codec_channels[n_codec]),
+                           SecondPart, Test_codec_channels[n_codec]));
+
+        encoder->end();
+
+        audio::sample_t decoder_samples[SamplesPerPacket * MaxChans];
+
+        UNSIGNED_LONGS_EQUAL(SamplesPerPacket,
+                             decoder->read_samples(*pp, 0, decoder_samples,
+                                                   SamplesPerPacket,
+                                                   Test_codec_channels[n_codec]));
+
+        check_samples(decoder_samples, 0, SamplesPerPacket, Test_codec_channels[n_codec]);
+    }
+}
+
+TEST(encoder, write_too_much) {
+    enum { SamplesPerPacket = 177 };
+
+    for (size_t n_codec = 0; n_codec < Test_NumCodecs; n_codec++) {
+        core::UniquePtr<audio::IEncoder> encoder(new_encoder(n_codec), allocator);
+        CHECK(encoder);
+
+        core::UniquePtr<audio::IDecoder> decoder(new_decoder(n_codec), allocator);
+        CHECK(decoder);
+
+        packet::PacketPtr pp = new_packet(encoder->payload_size(SamplesPerPacket));
+
+        encoder->begin(pp);
+
+        audio::sample_t encoder_samples[(SamplesPerPacket + 20) * MaxChans] = {};
+        fill_samples(encoder_samples, 0, SamplesPerPacket + 20,
+                     Test_codec_channels[n_codec]);
+
+        UNSIGNED_LONGS_EQUAL(SamplesPerPacket,
+                             encoder->write(encoder_samples, SamplesPerPacket + 20,
+                                            Test_codec_channels[n_codec]));
+
+        encoder->end();
+
+        audio::sample_t decoder_samples[SamplesPerPacket * MaxChans];
+
+        UNSIGNED_LONGS_EQUAL(SamplesPerPacket,
+                             decoder->read_samples(*pp, 0, decoder_samples,
+                                                   SamplesPerPacket,
+                                                   Test_codec_channels[n_codec]));
+
+        check_samples(decoder_samples, 0, SamplesPerPacket, Test_codec_channels[n_codec]);
+    }
+}
+
+TEST(encoder, write_channel_mask) {
+    enum {
+        FirstPart = 33,
+        SecondPart = 44,
+        FirstPartChans = 0xff,
+        SecondPartChans = 0x1,
+        SamplesPerPacket = FirstPart + SecondPart
+    };
+
+    for (size_t n_codec = 0; n_codec < Test_NumCodecs; n_codec++) {
+        core::UniquePtr<audio::IEncoder> encoder(new_encoder(n_codec), allocator);
+        CHECK(encoder);
+
+        core::UniquePtr<audio::IDecoder> decoder(new_decoder(n_codec), allocator);
+        CHECK(decoder);
+
+        packet::PacketPtr pp = new_packet(encoder->payload_size(SamplesPerPacket));
+
+        encoder->begin(pp);
+
+        size_t encoder_pos = 0;
+
+        {
+            audio::sample_t encoder_samples[FirstPart * MaxChans] = {};
+            encoder_pos =
+                fill_samples(encoder_samples, encoder_pos, FirstPart, FirstPartChans);
+
+            UNSIGNED_LONGS_EQUAL(
+                FirstPart, encoder->write(encoder_samples, FirstPart, FirstPartChans));
+        }
+
+        {
+            audio::sample_t encoder_samples[SecondPart * MaxChans] = {};
+            encoder_pos =
+                fill_samples(encoder_samples, encoder_pos, SecondPart, SecondPartChans);
+
+            UNSIGNED_LONGS_EQUAL(
+                SecondPart, encoder->write(encoder_samples, SecondPart, SecondPartChans));
+        }
+
+        encoder->end();
+
+        audio::sample_t decoder_samples[SamplesPerPacket * MaxChans];
+
+        UNSIGNED_LONGS_EQUAL(SamplesPerPacket,
+                             decoder->read_samples(*pp, 0, decoder_samples,
+                                                   SamplesPerPacket,
+                                                   Test_codec_channels[n_codec]));
+
+        size_t actual_pos = 0;
+        size_t expected_pos = 0;
+
+        for (size_t i = 0; i < FirstPart; i++) {
+            for (size_t j = 0; j < packet::num_channels(FirstPartChans); j++) {
+                if (Test_codec_channels[n_codec] & (1 << j)) {
+                    audio::sample_t actual = decoder_samples[actual_pos++];
+                    audio::sample_t expected = nth_sample(uint8_t(expected_pos));
+
+                    DOUBLES_EQUAL(expected, actual, Epsilon);
+                }
+
+                expected_pos++;
+            }
+        }
+
+        for (size_t i = FirstPart; i < SamplesPerPacket; i++) {
+            for (size_t j = 0; j < packet::num_channels(Test_codec_channels[n_codec]);
+                 j++) {
+                audio::sample_t actual = decoder_samples[actual_pos++];
+                audio::sample_t expected = 0;
+
+                if (SecondPartChans & (1 << j)) {
+                    expected = nth_sample(uint8_t(expected_pos++));
+                }
+
+                DOUBLES_EQUAL(expected, actual, Epsilon);
+            }
+        }
+    }
+}
+
+} // namespace rtp
+} // namespace roc


### PR DESCRIPTION
Resolves #211 and #58.

Changes:

* Rework audio::IEncoder and audio::IDecoder interfaces. Move RTP-specific part from Packetizer and Depacketizer to PCMEncoder and PCMDecoder. This will allow us to fix packet truncation (#187) and implement Opus codecs (#51).

* Rework PCM helpers. Introduce PCMFuncs and use it in PCMEncoder and PCMDecoder. This allowed us to make PCMEncoder and PCMDecoder non-templates.

* Add tests for PCMEncoder and PCMDecoder.

What's next (to be addressed in next PRs):

* Fix packet truncation / padding.