### PR TITLE
Fix bind options

### DIFF
--- a/docs/sphinx/manuals/roc_recv.rst
+++ b/docs/sphinx/manuals/roc_recv.rst
@@ -104,23 +104,35 @@ Time
 EXAMPLES
 ========
 
-Listen on two ports on all interfaces:
+Listen on two ports on all IPv4 interfaces (but not IPv6):
 
 .. code::
 
     $ roc-recv -vv -s rtp+rs8m::10001 -r rs8m::10002
 
-Listen on two ports on particular interface:
+Listen on two ports on all IPv6 interfaces (but not IPv4):
+
+.. code::
+
+    $ roc-recv -vv -s rtp+rs8m:[::]:10001 -r rs8m:[::]:10002
+
+Listen on two ports on a particular interface:
 
 .. code::
 
     $ roc-recv -vv -s rtp+rs8m:192.168.0.3:10001 -r rs8m:192.168.0.3:10002
 
-Listen on multiple ports (two for Reed-Solomon, two for LDPC, one for bare RTP):
+Listen on two Reed-Solomon ports, two LDPC ports, and one bare RTP port:
 
 .. code::
 
     $ roc-recv -vv -s rtp+rs8m::10001 -r rs8m::10002 -s rtp+ldpc::10003 -r ldpc::10004 -s rtp::10005
+
+Listen on two ports on all IPv4 interfaces and on two ports on all IPv6 interfaces:
+
+.. code::
+
+    $ roc-recv -vv -s rtp+rs8m::10001 -r rs8m::10002 -s rtp+rs8m:[::]:10001 -r rs8m:[::]:10002
 
 Output to the default ALSA device:
 

--- a/docs/sphinx/manuals/roc_send.rst
+++ b/docs/sphinx/manuals/roc_send.rst
@@ -101,6 +101,12 @@ Send WAV file:
 
     $ roc-send -vv -s rtp+rs8m:192.168.0.3:10001 -r rs8m:192.168.0.3:10002 -i ./file.wav
 
+Send WAV file to an IPv6 receiver:
+
+.. code::
+
+    $ roc-send -vv -s rtp+rs8m:[2001:db8::]:10001 -r rs8m:[2001:db8::]:10002 -i ./file.wav
+
 Send WAV from stdin:
 
 .. code::

--- a/src/modules/roc_netio/target_uv/roc_netio/udp_sender.cpp
+++ b/src/modules/roc_netio/target_uv/roc_netio/udp_sender.cpp
@@ -56,13 +56,20 @@ bool UDPSender::start(packet::Address& bind_address) {
     handle_initialized_ = true;
 
     unsigned flags = 0;
-    if (bind_address.port() > 0) {
+    if (bind_address.multicast() && bind_address.port() > 0) {
         flags |= UV_UDP_REUSEADDR;
     }
 
-    if (int err = uv_udp_bind(&handle_, bind_address.saddr(), flags)) {
-        roc_log(LogError, "udp sender: uv_udp_bind(): [%s] %s", uv_err_name(err),
-                uv_strerror(err));
+    int bind_err = UV_EINVAL;
+    if (bind_address.version() == 6) {
+        bind_err = uv_udp_bind(&handle_, bind_address.saddr(), flags | UV_UDP_IPV6ONLY);
+    }
+    if (bind_err == UV_EINVAL || bind_err == UV_ENOTSUP) {
+        bind_err = uv_udp_bind(&handle_, bind_address.saddr(), flags);
+    }
+    if (bind_err != 0) {
+        roc_log(LogError, "udp sender: uv_udp_bind(): [%s] %s", uv_err_name(bind_err),
+                uv_strerror(bind_err));
         return false;
     }
 

--- a/src/modules/roc_packet/target_posix/roc_packet/address.cpp
+++ b/src/modules/roc_packet/target_posix/roc_packet/address.cpp
@@ -92,6 +92,17 @@ int Address::port() const {
     }
 }
 
+bool Address::multicast() const {
+    switch (family_()) {
+    case AF_INET:
+        return IN_MULTICAST(ntohl(sa_.addr4.sin_addr.s_addr));
+    case AF_INET6:
+        return IN6_IS_ADDR_MULTICAST(&sa_.addr6.sin6_addr);
+    default:
+        return false;
+    }
+}
+
 bool Address::get_ip(char* buf, size_t bufsz) const {
     switch (family_()) {
     case AF_INET:

--- a/src/modules/roc_packet/target_posix/roc_packet/address.h
+++ b/src/modules/roc_packet/target_posix/roc_packet/address.h
@@ -53,6 +53,9 @@ public:
     //! Get address port.
     int port() const;
 
+    //! Check whether this is multicast address.
+    bool multicast() const;
+
     //! Get IP address.
     bool get_ip(char* buf, size_t bufsz) const;
 

--- a/src/tests/roc_packet/test_address.cpp
+++ b/src/tests/roc_packet/test_address.cpp
@@ -127,5 +127,72 @@ TEST(address, eq_ipv6) {
     CHECK(addr1 != addr4);
 }
 
+TEST(address, multicast_ipv4) {
+    {
+        Address addr;
+        CHECK(addr.set_ipv4("223.255.255.255", 123));
+        CHECK(addr.valid());
+        CHECK(!addr.multicast());
+    }
+
+    {
+        Address addr;
+        CHECK(addr.set_ipv4("224.0.0.0", 123));
+        CHECK(addr.valid());
+        CHECK(addr.multicast());
+    }
+
+    {
+        Address addr;
+        CHECK(addr.set_ipv4("227.128.128.128", 123));
+        CHECK(addr.valid());
+        CHECK(addr.multicast());
+    }
+
+    {
+        Address addr;
+        CHECK(addr.set_ipv4("239.255.255.255", 123));
+        CHECK(addr.valid());
+        CHECK(addr.multicast());
+    }
+
+    {
+        Address addr;
+        CHECK(addr.set_ipv4("240.0.0.0", 123));
+        CHECK(addr.valid());
+        CHECK(!addr.multicast());
+    }
+}
+
+TEST(address, multicast_ipv6) {
+    {
+        Address addr;
+        CHECK(addr.set_ipv6("fe00::", 123));
+        CHECK(addr.valid());
+        CHECK(!addr.multicast());
+    }
+
+    {
+        Address addr;
+        CHECK(addr.set_ipv6("ff00::", 123));
+        CHECK(addr.valid());
+        CHECK(addr.multicast());
+    }
+
+    {
+        Address addr;
+        CHECK(addr.set_ipv6("ff11:1:1:1:1:1:1:1", 123));
+        CHECK(addr.valid());
+        CHECK(addr.multicast());
+    }
+
+    {
+        Address addr;
+        CHECK(addr.set_ipv6("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", 123));
+        CHECK(addr.valid());
+        CHECK(addr.multicast());
+    }
+}
+
 } // namespace packet
 } // namespace roc

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -196,7 +196,12 @@ int main(int argc, char** argv) {
     }
 
     packet::Address local_addr;
-    if (!local_addr.set_ipv4("0.0.0.0", 0)) {
+    if (source_port.address.version() == 6) {
+        local_addr.set_ipv6("::", 0);
+    } else {
+        local_addr.set_ipv4("0.0.0.0", 0);
+    }
+    if (!local_addr.valid()) {
         roc_panic("can't initialize local address");
     }
 


### PR DESCRIPTION
Resolves #15.

See https://github.com/roc-project/roc/issues/15#issuecomment-497825248 for how it was tested.

Changes:

- Use UV_UDP_REUSEADDR only for multicast addresses. It's not needed
  and is actually harmful for UDP in case of unicast addresses.

- Use UV_UDP_IPV6ONLY for IPv6 addresses. This is the only way to
  provide an identical behaviour across all platforms and thereby
  allow the user to write portable code.

  If the user wants to bind both to IPv4 and IPv6, and IPV6_V6ONLY is
  enabled, the user should bind two ports (one IPv4 and one IPv6).

  If the user wants to bind both to IPv4 and IPv6, and IPV6_V6ONLY is
  disabled, the user should bind only one IPv6 port. Trying to also
  bind an IPv4 port will cause EADDRINUSE.

  At the same time:

  1) it's portable to enable IPV6_V6ONLY

  2) but it's not portable to disable IPV6_V6ONLY
     (some systems doesn't allow this, e.g. OpenBSD)

  3) and it's not portable to keep the default state of IPV6_V6ONLY
     (it is different of different systems)

  Hence, it seems that the only way to write portable code that
  binds both to IPv4 and IPv6 is to enable IPV6_V6ONLY and then
  explicitly bind two ports.

  Hence, Roc will always try to use IPV6_V6ONLY and force the user to
  bind IPv4 and IPv6 ports individually. This will make the code using
  Roc API portable.

- If binding with IPV6_V6ONLY is not working, try binding without it.

  This is a fallback for systems where IPV6_V6ONLY is not available or
  is read-only. Hopefully, these systems also don't have IPv4 to IPv6
  mapping, so IPV6_V6ONLY is not really needed. This is at least true
  for OpenBSD.

- Bind sender either to "[::]" or "0.0.0.0" according to whether IPv6
  or IPv4 is used for receiver.