### PR TITLE
Fixes #241 Add git SHA to build version info

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -548,6 +548,8 @@ build_dir = 'build/%s/%s' % (
 
 env['ROC_BINDIR'] = '#bin/%s' % host
 env['ROC_VERSION'] = open(env.File('#.version').path).read().strip()
+env['ROC_SHA'] = os.popen("cat .git/$(cat .git/HEAD | awk '{print $2}') | cut -b1-10").read().strip()
+env['ROC_VERSION_STR'] = env['ROC_VERSION'] + "-" + env['ROC_SHA']
 
 abi_version = '.'.join(env['ROC_VERSION'].split('.')[:2])
 

--- a/SConstruct
+++ b/SConstruct
@@ -548,8 +548,8 @@ build_dir = 'build/%s/%s' % (
 
 env['ROC_BINDIR'] = '#bin/%s' % host
 env['ROC_VERSION'] = open(env.File('#.version').path).read().strip()
-env['ROC_SHA'] = os.popen("cat .git/$(cat .git/HEAD | awk '{print $2}') | cut -b1-10").read().strip()
-env['ROC_VERSION_STR'] = env['ROC_VERSION'] + "-" + env['ROC_SHA']
+env['ROC_SHA'] = env.ParseGitHead()
+env['ROC_VERSION_STR'] = env['ROC_VERSION'] + '-' + env['ROC_SHA']
 
 abi_version = '.'.join(env['ROC_VERSION'].split('.')[:2])
 

--- a/site_scons/site_tools/roc/parsers.py
+++ b/site_scons/site_tools/roc/parsers.py
@@ -14,9 +14,13 @@ def ParseVersion(env, command):
 def ParseGitHead(env):
     with open('.git/HEAD') as hf:
         head_ref = hf.read().strip().split()[-1]
-        with open('.git/%s' % (head_ref)) as hrf:
-            sha = hrf.read().strip()[:10]
-
+        pattern = re.compile(r'\b[0-9a-f]{40}\b')
+        is_sha = re.match(pattern, head_ref)
+        if is_sha:
+            sha = head_ref[:10]
+        else:
+            with open('.git/%s' % (head_ref)) as hrf:
+                sha = hrf.read().strip()[:10]
     return sha
 
 def ParseCompilerVersion(env, compiler):

--- a/site_scons/site_tools/roc/parsers.py
+++ b/site_scons/site_tools/roc/parsers.py
@@ -11,6 +11,14 @@ def ParseVersion(env, command):
 
     return m.group(1)
 
+def ParseGitHead(env):
+    with open('.git/HEAD') as hf:
+        head_ref = hf.read().strip().split()[-1]
+        with open('.git/%s' % (head_ref)) as hrf:
+            sha = hrf.read().strip()[:10]
+
+    return sha
+
 def ParseCompilerVersion(env, compiler):
     def getverstr():
         try:
@@ -118,6 +126,7 @@ def ParseList(env, s, all):
 
 def init(env):
     env.AddMethod(ParseVersion, 'ParseVersion')
+    env.AddMethod(ParseGitHead, 'ParseGitHead')
     env.AddMethod(ParseCompilerVersion, 'ParseCompilerVersion')
     env.AddMethod(ParseCompilerTarget, 'ParseCompilerTarget')
     env.AddMethod(ParseCompilerDirectory, 'ParseCompilerDirectory')

--- a/src/SConscript
+++ b/src/SConscript
@@ -128,7 +128,7 @@ if not GetOption('disable_tools'):
         sources = env.Glob('%s/*.cpp' % tooldir)
         objects = []
         for ggo in env.Glob('%s/*.ggo' % tooldir):
-            objects += gen_env.GenGetOpt(ggo, env['ROC_VERSION'])
+            objects += gen_env.GenGetOpt(ggo, env['ROC_VERSION_STR'])
 
         exename = tooldir.name.replace('roc_', 'roc-')
         target = env.Install(env['ROC_BINDIR'],


### PR DESCRIPTION
Took a stab at this.. let me know if it's what you had in mind. 

`paul@thinkpad ~/roc-dev (feature/malcops/git-sha-to-version-info) $ ./bin/x86_64-pc-linux-gnu/roc-conv --version
roc-conv 0.1.2-e09a148c7b`
`paul@thinkpad ~/roc-dev (feature/malcops/git-sha-to-version-info) $ ./bin/x86_64-pc-linux-gnu/roc-recv --version
roc-recv 0.1.2-e09a148c7b`
`paul@thinkpad ~/roc-dev (feature/malcops/git-sha-to-version-info) $ ./bin/x86_64-pc-linux-gnu/roc-conv --version
roc-conv 0.1.2-e09a148c7b`

