### PR TITLE
Added --list-drivers -L support Issue:251

### DIFF
--- a/src/modules/roc_fec/target_openfec/roc_fec/of_decoder.cpp
+++ b/src/modules/roc_fec/target_openfec/roc_fec/of_decoder.cpp
@@ -294,11 +294,11 @@ void OFDecoder::reset_session_() {
 
     if (OF_STATUS_OK
         != of_set_callback_functions(
-            of_sess_, source_cb_,
-            // OpenFEC doesn't repair fec-packets in case of Reed-Solomon FEC
-            // and prints curses to the console if we give it the callback for that
-            codec_id_ == OF_CODEC_REED_SOLOMON_GF_2_M_STABLE ? NULL : repair_cb_,
-            (void*)this)) {
+               of_sess_, source_cb_,
+               // OpenFEC doesn't repair fec-packets in case of Reed-Solomon FEC
+               // and prints curses to the console if we give it the callback for that
+               codec_id_ == OF_CODEC_REED_SOLOMON_GF_2_M_STABLE ? NULL : repair_cb_,
+               (void*)this)) {
         roc_panic("of decoder: of_set_callback_functions() failed");
     }
 }

--- a/src/modules/roc_sndio/DriverInfo.cpp
+++ b/src/modules/roc_sndio/DriverInfo.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Sink Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_sndio/DriverInfo.h"
+
+namespace roc {
+namespace sndio {} // namespace sndio
+} // namespace roc

--- a/src/modules/roc_sndio/DriverInfo.h
+++ b/src/modules/roc_sndio/DriverInfo.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_sndio/DriverInfo.h
+//! @brief Driver info interface.
+
+#ifndef ROC_SNDIO_DRIVERINFO_H_
+#define ROC_SNDIO_DRIVERINFO_H_
+
+namespace roc {
+namespace sndio {
+
+//! Driver info interface.
+class DriverInfo {
+public:
+    DriverInfo();
+    DriverInfo(const char* name)
+        : name(name){};
+    const char* name;
+};
+
+} // namespace sndio
+} // namespace roc
+
+#endif // ROC_SNDIO_DRIVERINFO_H_

--- a/src/modules/roc_sndio/backend_dispatcher.cpp
+++ b/src/modules/roc_sndio/backend_dispatcher.cpp
@@ -90,5 +90,11 @@ void BackendDispatcher::add_backend_(IBackend& backend) {
     backends_[n_backends_++] = &backend;
 }
 
+void BackendDispatcher::get_drivers(core::Array<DriverInfo>& arr) {
+    for (size_t n = 0; n < n_backends_; n++) {
+        backends_[n]->get_drivers(arr);
+    }
+}
+
 } // namespace sndio
 } // namespace roc

--- a/src/modules/roc_sndio/backend_dispatcher.h
+++ b/src/modules/roc_sndio/backend_dispatcher.h
@@ -12,10 +12,12 @@
 #ifndef ROC_SNDIO_BACKEND_DISPATCHER_H_
 #define ROC_SNDIO_BACKEND_DISPATCHER_H_
 
+#include "roc_core/array.h"
 #include "roc_core/iallocator.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/shared_ptr.h"
 #include "roc_core/singleton.h"
+#include "roc_sndio/DriverInfo.h"
 #include "roc_sndio/ibackend.h"
 #include "roc_sndio/isink.h"
 #include "roc_sndio/isource.h"
@@ -45,6 +47,9 @@ public:
                          const char* driver,
                          const char* input,
                          const Config& config);
+
+    //! Append supported dirvers from all registered backends to Array
+    void get_drivers(core::Array<DriverInfo>& arr);
 
 private:
     friend class core::Singleton<BackendDispatcher>;

--- a/src/modules/roc_sndio/ibackend.h
+++ b/src/modules/roc_sndio/ibackend.h
@@ -12,8 +12,10 @@
 #ifndef ROC_SNDIO_IBACKEND_H_
 #define ROC_SNDIO_IBACKEND_H_
 
+#include "roc_core/array.h"
 #include "roc_core/iallocator.h"
 #include "roc_core/shared_ptr.h"
+#include "roc_sndio/DriverInfo.h"
 #include "roc_sndio/config.h"
 #include "roc_sndio/isink.h"
 #include "roc_sndio/isource.h"
@@ -55,6 +57,9 @@ public:
                                  const char* driver,
                                  const char* input,
                                  const Config& config) = 0;
+
+    //! Append supported dirvers to Array
+    virtual void get_drivers(core::Array<DriverInfo>& arr) = 0;
 };
 
 } // namespace sndio

--- a/src/modules/roc_sndio/target_pulseaudio/roc_sndio/pulseaudio_backend.cpp
+++ b/src/modules/roc_sndio/target_pulseaudio/roc_sndio/pulseaudio_backend.cpp
@@ -57,5 +57,19 @@ ISource* PulseaudioBackend::open_source(core::IAllocator&,
     return NULL;
 }
 
+void PulseaudioBackend::get_drivers(core::Array<DriverInfo>& arr) {
+    const char* format_name = "pulseaudio";
+    size_t n;
+    for (n = 0; n < arr.size(); n++) {
+        if (strcmp(format_name, arr[n].name) == 0) {
+            return;
+        }
+    }
+    if (arr.grow(arr.size() + 1)) {
+        DriverInfo newDriver(format_name);
+        arr.push_back(newDriver);
+    }
+}
+
 } // namespace sndio
 } // namespace roc

--- a/src/modules/roc_sndio/target_pulseaudio/roc_sndio/pulseaudio_backend.h
+++ b/src/modules/roc_sndio/target_pulseaudio/roc_sndio/pulseaudio_backend.h
@@ -12,8 +12,10 @@
 #ifndef ROC_SNDIO_PULSEAUDIO_BACKEND_H_
 #define ROC_SNDIO_PULSEAUDIO_BACKEND_H_
 
+#include "roc_core/array.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/singleton.h"
+#include "roc_sndio/DriverInfo.h"
 #include "roc_sndio/ibackend.h"
 
 namespace roc {
@@ -41,6 +43,9 @@ public:
                                  const char* driver,
                                  const char* input,
                                  const Config& config);
+
+    //! Append supported drivers to Array
+    virtual void get_drivers(core::Array<DriverInfo>& arr);
 
 private:
     friend class core::Singleton<PulseaudioBackend>;

--- a/src/modules/roc_sndio/target_sox/roc_sndio/sox_backend.h
+++ b/src/modules/roc_sndio/target_sox/roc_sndio/sox_backend.h
@@ -50,6 +50,9 @@ public:
                                  const char* input,
                                  const Config& config);
 
+    //! Append supported dirvers to Array
+    virtual void get_drivers(core::Array<DriverInfo>& arr);
+
 private:
     friend class core::Singleton<SoxBackend>;
 

--- a/src/tests/roc_audio/test_freq_estimator.cpp
+++ b/src/tests/roc_audio/test_freq_estimator.cpp
@@ -21,7 +21,7 @@ const double Epsilon = 0.0001;
 
 } // namespace
 
-TEST_GROUP(freq_estimator) {};
+TEST_GROUP(freq_estimator){};
 
 TEST(freq_estimator, initial) {
     FreqEstimator fe(Target);

--- a/src/tests/roc_audio/test_packetizer.cpp
+++ b/src/tests/roc_audio/test_packetizer.cpp
@@ -156,7 +156,7 @@ private:
 
 } // namespace
 
-TEST_GROUP(packetizer) {};
+TEST_GROUP(packetizer){};
 
 TEST(packetizer, one_buffer_one_packet) {
     enum { NumFrames = 10 };

--- a/src/tests/roc_core/target_posix/test_format_time.cpp
+++ b/src/tests/roc_core/target_posix/test_format_time.cpp
@@ -23,7 +23,7 @@ enum {
 
 } // namespace
 
-TEST_GROUP(format_time) {};
+TEST_GROUP(format_time){};
 
 TEST(format_time, buffer_size) {
     char buf[64];

--- a/src/tests/roc_core/target_stdio/test_parse_duration.cpp
+++ b/src/tests/roc_core/target_stdio/test_parse_duration.cpp
@@ -14,7 +14,7 @@
 namespace roc {
 namespace core {
 
-TEST_GROUP(parse_duration) {};
+TEST_GROUP(parse_duration){};
 
 TEST(parse_duration, error) {
     nanoseconds_t result = 0;

--- a/src/tests/roc_core/test_atomic.cpp
+++ b/src/tests/roc_core/test_atomic.cpp
@@ -13,7 +13,7 @@
 namespace roc {
 namespace core {
 
-TEST_GROUP(atomic) {};
+TEST_GROUP(atomic){};
 
 TEST(atomic, init_load) {
     Atomic a1;

--- a/src/tests/roc_core/test_list_ownership.cpp
+++ b/src/tests/roc_core/test_list_ownership.cpp
@@ -26,7 +26,7 @@ typedef List<Object, RefCntOwnership> TestList;
 
 } // namespace
 
-TEST_GROUP(list_ownership) {};
+TEST_GROUP(list_ownership){};
 
 TEST(list_ownership, push_back) {
     Object obj;

--- a/src/tests/roc_core/test_time.cpp
+++ b/src/tests/roc_core/test_time.cpp
@@ -13,7 +13,7 @@
 namespace roc {
 namespace core {
 
-TEST_GROUP(time) {};
+TEST_GROUP(time){};
 
 TEST(time, timestamp) {
     const nanoseconds_t ts = timestamp();

--- a/src/tests/roc_fec/target_openfec/test_encoder_decoder.cpp
+++ b/src/tests/roc_fec/target_openfec/test_encoder_decoder.cpp
@@ -99,7 +99,7 @@ private:
     core::Array<core::Slice<uint8_t> > buffers_;
 };
 
-TEST_GROUP(encoder_decoder) {};
+TEST_GROUP(encoder_decoder){};
 
 TEST(encoder_decoder, without_loss) {
     enum { NumSourcePackets = 20, NumRepairPackets = 10, PayloadSize = 251 };

--- a/src/tests/roc_fec/test_composer.cpp
+++ b/src/tests/roc_fec/test_composer.cpp
@@ -17,7 +17,7 @@
 namespace roc {
 namespace fec {
 
-TEST_GROUP(composer) {};
+TEST_GROUP(composer){};
 
 TEST(composer, align_footer) {
     enum { BufferSize = 100, Alignment = 8 };

--- a/src/tests/roc_lib/test_address.cpp
+++ b/src/tests/roc_lib/test_address.cpp
@@ -14,7 +14,7 @@
 
 namespace roc {
 
-TEST_GROUP(address) {};
+TEST_GROUP(address){};
 
 TEST(address, ipv4) {
     char buf[16];

--- a/src/tests/roc_lib/test_context.cpp
+++ b/src/tests/roc_lib/test_context.cpp
@@ -14,7 +14,7 @@
 
 namespace roc {
 
-TEST_GROUP(context) {};
+TEST_GROUP(context){};
 
 TEST(context, open_close) {
     roc_context_config config;

--- a/src/tests/roc_netio/test_transceiver.cpp
+++ b/src/tests/roc_netio/test_transceiver.cpp
@@ -34,7 +34,7 @@ packet::Address make_address(const char* ip, int port) {
 
 } // namespace
 
-TEST_GROUP(transceiver) {};
+TEST_GROUP(transceiver){};
 
 TEST(transceiver, init) {
     Transceiver trx(packet_pool, buffer_pool, allocator);

--- a/src/tests/roc_packet/test_address.cpp
+++ b/src/tests/roc_packet/test_address.cpp
@@ -14,7 +14,7 @@
 namespace roc {
 namespace packet {
 
-TEST_GROUP(address) {};
+TEST_GROUP(address){};
 
 TEST(address, invalid) {
     Address addr;

--- a/src/tests/roc_packet/test_units.cpp
+++ b/src/tests/roc_packet/test_units.cpp
@@ -13,7 +13,7 @@
 namespace roc {
 namespace packet {
 
-TEST_GROUP(units) {};
+TEST_GROUP(units){};
 
 TEST(units, seqnum_diff) {
     const seqnum_t v = 65535;

--- a/src/tests/roc_pipeline/target_stdio/test_port.cpp
+++ b/src/tests/roc_pipeline/target_stdio/test_port.cpp
@@ -14,7 +14,7 @@
 namespace roc {
 namespace pipeline {
 
-TEST_GROUP(port) {};
+TEST_GROUP(port){};
 
 TEST(port, all_fields) {
     PortConfig port;

--- a/src/tools/roc_recv/cmdline.ggo
+++ b/src/tools/roc_recv/cmdline.ggo
@@ -3,6 +3,8 @@ usage "roc-recv OPTIONS"
 
 section "Options"
 
+    option "list-drivers" L "Lists all supported audio drivers" optional
+
     option "verbose" v "Increase verbosity level (may be used multiple times)"
         multiple optional
 

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "roc_audio/resampler_profile.h"
+#include "roc_core/array.h"
 #include "roc_core/crash.h"
 #include "roc_core/heap_allocator.h"
 #include "roc_core/log.h"
@@ -16,6 +17,7 @@
 #include "roc_netio/transceiver.h"
 #include "roc_pipeline/parse_port.h"
 #include "roc_pipeline/receiver.h"
+#include "roc_sndio/DriverInfo.h"
 #include "roc_sndio/backend_dispatcher.h"
 #include "roc_sndio/pump.h"
 
@@ -40,6 +42,15 @@ int main(int argc, char** argv) {
         LogLevel(core::DefaultLogLevel + args.verbose_given));
 
     pipeline::ReceiverConfig config;
+
+    if (args.list_drivers_given) {
+        core::HeapAllocator allocator;
+        core::Array<sndio::DriverInfo> DriverList(allocator);
+        sndio::BackendDispatcher::instance().get_drivers(DriverList);
+        for (size_t n = 0; n < DriverList.size(); n++) {
+            printf("%s \n", DriverList[n].name);
+        }
+    }
 
     size_t max_packet_size = 2048;
     if (args.packet_limit_given) {

--- a/src/tools/roc_send/cmdline.ggo
+++ b/src/tools/roc_send/cmdline.ggo
@@ -3,6 +3,8 @@ usage "roc-send OPTIONS"
 
 section "Options"
 
+    option "list-drivers" L "Lists all supported audio drivers" optional
+    
     option "verbose" v "Increase verbosity level (may be used multiple times)"
         multiple optional
 

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "roc_audio/resampler_profile.h"
+#include "roc_core/array.h"
 #include "roc_core/crash.h"
 #include "roc_core/heap_allocator.h"
 #include "roc_core/log.h"
@@ -17,6 +18,7 @@
 #include "roc_pipeline/parse_port.h"
 #include "roc_pipeline/port_utils.h"
 #include "roc_pipeline/sender.h"
+#include "roc_sndio/DriverInfo.h"
 #include "roc_sndio/backend_dispatcher.h"
 #include "roc_sndio/pump.h"
 
@@ -41,6 +43,15 @@ int main(int argc, char** argv) {
         LogLevel(core::DefaultLogLevel + args.verbose_given));
 
     pipeline::SenderConfig config;
+
+    if (args.list_drivers_given) {
+        core::HeapAllocator allocator;
+        core::Array<sndio::DriverInfo> DriverList(allocator);
+        sndio::BackendDispatcher::instance().get_drivers(DriverList);
+        for (size_t n = 0; n < DriverList.size(); n++) {
+            printf("%s \n", DriverList[n].name);
+        }
+    }
 
     if (args.packet_length_given) {
         if (!core::parse_duration(args.packet_length_arg, config.packet_length)) {


### PR DESCRIPTION
Made the get_drivers function an abstract function for the iBackend class. Also updated the ggo/ main.cpp files accordingly.

Currently sox can support all of the following formats/ audio device drivers (based on what sox_get_format_fn gives me)

AUDIO FILE FORMATS: aifc aiffc aiff aif al au snd avr cdda cdr cvsd cvs cvu dat dvms vms f4 f32 f8 f64 gsrt hcom htk ima la lu maud prc raw s1 s8 sb s2 s16 sw s3 s24 s4 s32 sl sf ircam sln smp sndr sndt sox sph nist 8svx txw u1 u8 ub sou fssd u2 u16 uw u3 u24 u4 u32 ul voc vox wav wavpcm amb wve xa gsm lpc10 lpc
PLAYLIST FORMATS: m3u pls
AUDIO DEVICE DRIVERS: alsa ossdsp oss pulseaudio

I wasn't sure if there needs to be any separation between Audio FIle formats and device drivers, so I just bundled them together in the output.

