### PR TITLE
Colored logs (#272)

### DIFF
--- a/src/modules/roc_core/target_posix/roc_core/colors.cpp
+++ b/src/modules/roc_core/target_posix/roc_core/colors.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "roc_core/colors.h"
+
+//! ANSI Color Codes.
+#define COLOR_NONE ""
+#define COLOR_START "\033["
+#define COLOR_END "m"
+#define COLOR_RESET COLOR_START "0" COLOR_END
+#define COLOR_SEPARATOR ";"
+#define COLOR_BOLD "1"
+#define COLOR_RED "31"
+#define COLOR_BLUE "34"
+
+namespace roc {
+namespace core {
+
+namespace {
+char const* colors_to_levels(LogLevel level) {
+    char const* color = COLOR_NONE;
+    switch (level) {
+    case LogNone: //!< No color for Loglevel None.
+        break;
+    case LogError: //!< Bold Red for Loglevel Error.
+        color = COLOR_START COLOR_BOLD COLOR_SEPARATOR COLOR_RED COLOR_END;
+        break;
+    case LogInfo: //!< Bold Blue for Loglevel Info.
+        color = COLOR_START COLOR_BOLD COLOR_SEPARATOR COLOR_BLUE COLOR_END;
+        break;
+    case LogDebug: //!< No color for Loglevel Debug.
+        break;
+    case LogTrace: //!< No color for Loglevel Trace.
+        break;
+    }
+    return color;
+}
+} // namespace
+
+bool colors_available() {
+    char* term = getenv("TERM");
+    return isatty(STDERR_FILENO) && term && strncmp("dumb", term, 4) != 0;
+}
+
+bool format_colored(LogLevel level, const char* str, char* buf, size_t bufsz) {
+    roc_panic_if_not(str);
+    roc_panic_if_not(buf);
+    int printed =
+        snprintf(buf, bufsz, "%s%s%s", colors_to_levels(level), str, COLOR_RESET);
+    return printed > 0 && (size_t)printed < bufsz;
+}
+
+} // namespace core
+} // namespace roc

--- a/src/modules/roc_core/target_posix/roc_core/colors.h
+++ b/src/modules/roc_core/target_posix/roc_core/colors.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_core/target_posix/roc_core/colors.h
+//! @brief Colorization functions.
+
+#ifndef ROC_CORE_COLORS_H_
+#define ROC_CORE_COLORS_H_
+
+#include "roc_core/log.h"
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace core {
+
+//! Check if current stderr is connected to a tty.
+bool colors_available();
+
+//! Fill colored str into buf according to the log level.
+bool format_colored(LogLevel level, const char* str, char* buf, size_t bufsz);
+
+} // namespace core
+} // namespace roc
+
+#endif // ROC_CORE_COLORS_H_

--- a/src/modules/roc_core/target_stdio/roc_core/log.h
+++ b/src/modules/roc_core/target_stdio/roc_core/log.h
@@ -41,6 +41,15 @@ namespace core {
 //! Default log level.
 const LogLevel DefaultLogLevel = LogError;
 
+//! Colors mode.
+enum ColorsMode {
+    ColorsDisabled, //!< Do not use colored logs.
+    ColorsEnabled   //!< Use colored logs.
+};
+
+//! Default colors mode.
+const ColorsMode DefaultColorsMode = ColorsDisabled;
+
 //! Log handler.
 typedef void (*LogHandler)(LogLevel level, const char* module, const char* message);
 
@@ -75,6 +84,12 @@ public:
     //!  Otherwise, they're printed to stderr.Default log handler is NULL.
     void set_handler(LogHandler handler);
 
+    //! Set colors mode.
+    //!
+    //! @note
+    //!  Default colors mode is ColorsAuto.
+    void set_colors(ColorsMode mode);
+
 private:
     friend class Singleton<Logger>;
 
@@ -84,6 +99,7 @@ private:
 
     LogLevel level_;
     LogHandler handler_;
+    ColorsMode colors_;
 };
 
 } // namespace core

--- a/src/tools/roc_conv/cmdline.ggo
+++ b/src/tools/roc_conv/cmdline.ggo
@@ -30,3 +30,6 @@ section "Options"
 
     option "poisoning" - "Enable uninitialized memory poisoning"
         flag off
+
+    option "color" - "Set colored logging mode for stderr output"
+        values="auto","always","never" default="auto" enum optional

--- a/src/tools/roc_conv/main.cpp
+++ b/src/tools/roc_conv/main.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "roc_audio/resampler_profile.h"
+#include "roc_core/colors.h"
 #include "roc_core/crash.h"
 #include "roc_core/heap_allocator.h"
 #include "roc_core/log.h"
@@ -36,6 +37,24 @@ int main(int argc, char** argv) {
 
     core::Logger::instance().set_level(
         LogLevel(core::DefaultLogLevel + args.verbose_given));
+
+    switch ((unsigned)args.color_arg) {
+    case color_arg_auto:
+        core::Logger::instance().set_colors(
+            core::colors_available() ? core::ColorsEnabled : core::ColorsDisabled);
+        break;
+
+    case color_arg_always:
+        core::Logger::instance().set_colors(core::ColorsMode(core::ColorsEnabled));
+        break;
+
+    case color_arg_never:
+        core::Logger::instance().set_colors(core::ColorsMode(core::ColorsDisabled));
+        break;
+
+    default:
+        break;
+    }
 
     core::HeapAllocator allocator;
 

--- a/src/tools/roc_recv/cmdline.ggo
+++ b/src/tools/roc_recv/cmdline.ggo
@@ -67,6 +67,9 @@ section "Options"
 
     option "beeping" - "Enable beeping on packet loss" flag off
 
+    option "color" - "Set colored logging mode for stderr output"
+        values="auto","always","never" default="auto" enum optional
+
 text "
 OUTPUT is the file name or device name, depending on the selected DRIVER, e.g.:
   file.wav; front:CARD=PCH,DEV=0; alsa_input.pci-0000_00_1f.3.analog-stereo;

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -8,6 +8,7 @@
 
 #include "roc_audio/resampler_profile.h"
 #include "roc_core/array.h"
+#include "roc_core/colors.h"
 #include "roc_core/crash.h"
 #include "roc_core/heap_allocator.h"
 #include "roc_core/log.h"
@@ -40,6 +41,24 @@ int main(int argc, char** argv) {
 
     core::Logger::instance().set_level(
         LogLevel(core::DefaultLogLevel + args.verbose_given));
+
+    switch ((unsigned)args.color_arg) {
+    case color_arg_auto:
+        core::Logger::instance().set_colors(
+            core::colors_available() ? core::ColorsEnabled : core::ColorsDisabled);
+        break;
+
+    case color_arg_always:
+        core::Logger::instance().set_colors(core::ColorsMode(core::ColorsEnabled));
+        break;
+
+    case color_arg_never:
+        core::Logger::instance().set_colors(core::ColorsMode(core::ColorsDisabled));
+        break;
+
+    default:
+        break;
+    }
 
     core::HeapAllocator allocator;
 

--- a/src/tools/roc_send/cmdline.ggo
+++ b/src/tools/roc_send/cmdline.ggo
@@ -50,6 +50,9 @@ section "Options"
     option "poisoning" - "Enable uninitialized memory poisoning"
         flag off
 
+    option "color" - "Set colored logging mode for stderr output"
+        values="auto","always","never" default="auto" enum optional
+
 text "
 INPUT is the file name or device name, depending on the selected DRIVER, e.g.:
   file.wav; front:CARD=PCH,DEV=0; alsa_input.pci-0000_00_1f.3.analog-stereo;

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -8,6 +8,7 @@
 
 #include "roc_audio/resampler_profile.h"
 #include "roc_core/array.h"
+#include "roc_core/colors.h"
 #include "roc_core/crash.h"
 #include "roc_core/heap_allocator.h"
 #include "roc_core/log.h"
@@ -41,6 +42,24 @@ int main(int argc, char** argv) {
 
     core::Logger::instance().set_level(
         LogLevel(core::DefaultLogLevel + args.verbose_given));
+
+    switch ((unsigned)args.color_arg) {
+    case color_arg_auto:
+        core::Logger::instance().set_colors(
+            core::colors_available() ? core::ColorsEnabled : core::ColorsDisabled);
+        break;
+
+    case color_arg_always:
+        core::Logger::instance().set_colors(core::ColorsMode(core::ColorsEnabled));
+        break;
+
+    case color_arg_never:
+        core::Logger::instance().set_colors(core::ColorsMode(core::ColorsDisabled));
+        break;
+
+    default:
+        break;
+    }
 
     core::HeapAllocator allocator;
 


### PR DESCRIPTION
![screenshot](https://i.imgur.com/YjqCopp.png)

This PR adds colors to `stderr` logging while attached to a tty by adding:
- `--color=auto|never|always` options to roc tools (`roc_conv`, `roc_recv`, `roc_send`)
- `roc::core::colors_available()`, `roc::core::format_colored()`, `roc::core::Logger::set_colors()` functions
See #272 for more details.

Thanks in advance for advices :)
