### PR TITLE
Fixing roc_lib test fails under valgrind

### DIFF
--- a/src/tests/roc_lib/test_sender_receiver.cpp
+++ b/src/tests/roc_lib/test_sender_receiver.cpp
@@ -186,7 +186,7 @@ public:
         size_t leading_zeros = 0;
         size_t sample_num = 0;
         size_t frame_num = 0;
-        
+
         size_t middle_stream_total = 0;
         size_t middle_stream_identical = 0;
 
@@ -222,22 +222,33 @@ public:
                         roc_log(LogDebug, "finish: leading_zeros: %lu, num_samples: %lu",
                                 (unsigned long)leading_zeros, (unsigned long)sample_num);
                         break;
-                    } 
-                    
+                    }
+
                     if (is_zero_(samples_[sample_num] - rx_buff[i])) {
                         middle_stream_identical++;
+                    } else if (!is_zero_(rx_buff[i])) {
+                        char sbuff[256];
+                        int sbuff_i =
+                            snprintf(sbuff, sizeof(sbuff),
+                                     "failed comparing sample #%lu\n\nframe_num: %lu\n",
+                                     (unsigned long)sample_num, (unsigned long)frame_num);
+                        snprintf(&sbuff[sbuff_i], sizeof(sbuff) - (size_t)sbuff_i,
+                                 "original: %f,\treceived: %f\n",
+                                 (double)samples_[sample_num], (double)rx_buff[i]);
+                        roc_panic("%s", sbuff);
                     }
                 }
             }
         }
 
-        double identical = (double)middle_stream_identical / middle_stream_total;          
-        if(identical < .9) {
+        double identical = (double)middle_stream_identical / middle_stream_total;
+        if (identical < .9) {
             char sbuff[256];
-            snprintf(sbuff, sizeof(sbuff), 
-                    "Middle stream identical by %f: %lu identical samples on %lu samples", 
-                    identical, (unsigned long)middle_stream_identical,
-                    (unsigned long)middle_stream_total);
+            snprintf(
+                sbuff, sizeof(sbuff),
+                "middle stream identical by %f: %lu identical samples on %lu samples",
+                identical, (unsigned long)middle_stream_identical,
+                (unsigned long)middle_stream_total);
             roc_panic("%s", sbuff);
         }
     }


### PR DESCRIPTION
Fix issue #223 

I've relaxed the test requirements to have a certain percentage (for now 90%) of identical middle stream samples.

Should it raises a panic if a sample is not identical and is different from zero ?