### PR TITLE
IoURI fixes

### DIFF
--- a/src/modules/roc_address/io_uri.cpp
+++ b/src/modules/roc_address/io_uri.cpp
@@ -7,25 +7,56 @@
  */
 
 #include "roc_address/io_uri.h"
+#include "roc_address/pct.h"
+#include "roc_core/string_utils.h"
 
 namespace roc {
 namespace address {
 
 IoURI::IoURI() {
-    scheme[0] = '\0';
-    path[0] = '\0';
+    scheme_[0] = '\0';
+    path_[0] = '\0';
 }
 
-bool IoURI::is_empty() const {
-    return !*scheme && !*path;
+bool IoURI::is_valid() const {
+    return *scheme_ && *path_;
 }
 
 bool IoURI::is_file() const {
-    return strcmp(scheme, "file") == 0;
+    return strcmp(scheme_, "file") == 0;
 }
 
 bool IoURI::is_special_file() const {
-    return strcmp(scheme, "file") == 0 && strcmp(path, "-") == 0;
+    return strcmp(scheme_, "file") == 0 && strcmp(path_, "-") == 0;
+}
+
+const char* IoURI::scheme() const {
+    if (!is_valid()) {
+        return "";
+    }
+    return scheme_;
+}
+
+const char* IoURI::path() const {
+    if (!is_valid()) {
+        return "";
+    }
+    return path_;
+}
+
+bool IoURI::set_scheme(const char* str, size_t str_len) {
+    return core::copy_str(scheme_, sizeof(scheme_), str, str + str_len);
+}
+
+bool IoURI::set_encoded_path(const char* str, size_t str_len) {
+    return pct_decode(path_, sizeof(path_), str, str_len) != -1;
+}
+
+bool IoURI::get_encoded_path(char* str, size_t str_len) const {
+    if (!is_valid()) {
+        return false;
+    }
+    return pct_encode(str, str_len, path_, strlen(path_), PctNonPath) != -1;
 }
 
 } // namespace address

--- a/src/modules/roc_address/io_uri.cpp
+++ b/src/modules/roc_address/io_uri.cpp
@@ -13,21 +13,32 @@
 namespace roc {
 namespace address {
 
-IoURI::IoURI() {
-    scheme_[0] = '\0';
-    path_[0] = '\0';
+IoURI::IoURI(core::IAllocator& allocator)
+    : path_(allocator) {
+    clear();
 }
 
 bool IoURI::is_valid() const {
-    return *scheme_ && *path_;
+    return *scheme_ && path_.size() != 0;
 }
 
 bool IoURI::is_file() const {
+    if (!is_valid()) {
+        return false;
+    }
     return strcmp(scheme_, "file") == 0;
 }
 
 bool IoURI::is_special_file() const {
-    return strcmp(scheme_, "file") == 0 && strcmp(path_, "-") == 0;
+    if (!is_valid()) {
+        return false;
+    }
+    return strcmp(scheme_, "file") == 0 && strcmp(&path_[0], "-") == 0;
+}
+
+void IoURI::clear() {
+    scheme_[0] = '\0';
+    path_.resize(0);
 }
 
 const char* IoURI::scheme() const {
@@ -41,22 +52,49 @@ const char* IoURI::path() const {
     if (!is_valid()) {
         return "";
     }
-    return path_;
+    return &path_[0];
 }
 
 bool IoURI::set_scheme(const char* str, size_t str_len) {
-    return core::copy_str(scheme_, sizeof(scheme_), str, str + str_len);
+    if (str_len < 1) {
+        clear();
+        return false;
+    }
+
+    if (!core::copy_str(scheme_, sizeof(scheme_), str, str + str_len)) {
+        clear();
+        return false;
+    }
+
+    return true;
 }
 
 bool IoURI::set_encoded_path(const char* str, size_t str_len) {
-    return pct_decode(path_, sizeof(path_), str, str_len) != -1;
+    if (str_len < 1) {
+        clear();
+        return false;
+    }
+
+    const size_t buf_size = str_len + 1;
+
+    if (!path_.resize(buf_size)) {
+        clear();
+        return false;
+    }
+
+    if (pct_decode(&path_[0], buf_size, str, str_len) == -1) {
+        clear();
+        return false;
+    }
+
+    return true;
 }
 
 bool IoURI::get_encoded_path(char* str, size_t str_len) const {
     if (!is_valid()) {
         return false;
     }
-    return pct_encode(str, str_len, path_, strlen(path_), PctNonPath) != -1;
+    return pct_encode(str, str_len, &path_[0], strlen(&path_[0]), PctNonPath) != -1;
 }
 
 } // namespace address

--- a/src/modules/roc_address/io_uri.h
+++ b/src/modules/roc_address/io_uri.h
@@ -12,18 +12,20 @@
 #ifndef ROC_ADDRESS_IO_URI_H_
 #define ROC_ADDRESS_IO_URI_H_
 
+#include "roc_core/noncopyable.h"
 #include "roc_core/stddefs.h"
 
 namespace roc {
 namespace address {
 
 //! Audio file or device URI.
-struct IoURI {
+class IoURI : public core::NonCopyable<> {
+public:
     //! Initialize empty URI.
     IoURI();
 
-    //! Returns true if the URI is empty.
-    bool is_empty() const;
+    //! Returns true if the URI has all required components.
+    bool is_valid() const;
 
     //! Returns true if the scheme is "file".
     bool is_file() const;
@@ -31,18 +33,31 @@ struct IoURI {
     //! Returns true if the scheme is "file" and the path is "-".
     bool is_special_file() const;
 
-    enum {
-        // An estimate maximum length of encoded URI.
-        MaxLength = 1280
-    };
-
     //! URI scheme.
     //! May be "file" or device type, e.g. "alsa".
-    char scheme[16];
+    const char* scheme() const;
 
     //! URI path.
     //! May be device name or file path depending on scheme.
-    char path[1024];
+    const char* path() const;
+
+    //! Set URI scheme.
+    //! String should not be zero-terminated.
+    bool set_scheme(const char* str, size_t str_len);
+
+    //! Set URI path.
+    //! String should be percent-encoded.
+    //! String should not be zero-terminated.
+    bool set_encoded_path(const char* str, size_t str_len);
+
+    //! Get URI path.
+    //! String will be percent-encoded.
+    //! String will be zero-terminated.
+    bool get_encoded_path(char* str, size_t str_len) const;
+
+private:
+    char scheme_[16];
+    char path_[1024];
 };
 
 //! Parse IoURI from string.

--- a/src/modules/roc_address/io_uri.h
+++ b/src/modules/roc_address/io_uri.h
@@ -12,6 +12,7 @@
 #ifndef ROC_ADDRESS_IO_URI_H_
 #define ROC_ADDRESS_IO_URI_H_
 
+#include "roc_core/array.h"
 #include "roc_core/noncopyable.h"
 #include "roc_core/stddefs.h"
 
@@ -22,9 +23,9 @@ namespace address {
 class IoURI : public core::NonCopyable<> {
 public:
     //! Initialize empty URI.
-    IoURI();
+    explicit IoURI(core::IAllocator&);
 
-    //! Returns true if the URI has all required components.
+    //! Returns true if the URI has all required fields (scheme and path).
     bool is_valid() const;
 
     //! Returns true if the scheme is "file".
@@ -33,17 +34,20 @@ public:
     //! Returns true if the scheme is "file" and the path is "-".
     bool is_special_file() const;
 
+    //! Clear all fields.
+    void clear();
+
     //! URI scheme.
     //! May be "file" or device type, e.g. "alsa".
     const char* scheme() const;
 
-    //! URI path.
-    //! May be device name or file path depending on scheme.
-    const char* path() const;
-
     //! Set URI scheme.
     //! String should not be zero-terminated.
     bool set_scheme(const char* str, size_t str_len);
+
+    //! URI path.
+    //! May be device name or file path depending on scheme.
+    const char* path() const;
 
     //! Set URI path.
     //! String should be percent-encoded.
@@ -57,7 +61,7 @@ public:
 
 private:
     char scheme_[16];
-    char path_[1024];
+    core::Array<char> path_;
 };
 
 //! Parse IoURI from string.

--- a/src/modules/roc_address/io_uri_format.cpp
+++ b/src/modules/roc_address/io_uri_format.cpp
@@ -23,29 +23,33 @@ bool format_io_uri(const IoURI& u, char* buf, size_t buf_size) {
 
     buf[0] = '\0';
 
-    if (*u.scheme) {
-        if (!core::append_str(buf, buf_size, u.scheme)) {
+    if (!*u.scheme) {
+        return false;
+    }
+
+    if (!core::append_str(buf, buf_size, u.scheme)) {
+        return false;
+    }
+
+    if (u.is_file()) {
+        if (!core::append_str(buf, buf_size, ":")) {
             return false;
         }
-
-        if (u.is_file()) {
-            if (!core::append_str(buf, buf_size, ":")) {
-                return false;
-            }
-        } else {
-            if (!core::append_str(buf, buf_size, "://")) {
-                return false;
-            }
+    } else {
+        if (!core::append_str(buf, buf_size, "://")) {
+            return false;
         }
     }
 
-    if (*u.path) {
-        const size_t pos = strlen(buf);
+    if (!*u.path) {
+        return false;
+    }
 
-        if (pct_encode(buf + pos, buf_size - pos, u.path, strlen(u.path), PctNonPath)
-            == -1) {
-            return false;
-        }
+    const size_t pos = strlen(buf);
+
+    if (pct_encode(buf + pos, buf_size - pos, u.path, strlen(u.path), PctNonPath)
+        == -1) {
+        return false;
     }
 
     return true;

--- a/src/modules/roc_address/io_uri_format.cpp
+++ b/src/modules/roc_address/io_uri_format.cpp
@@ -7,7 +7,6 @@
  */
 
 #include "roc_address/io_uri.h"
-#include "roc_address/pct.h"
 #include "roc_core/panic.h"
 #include "roc_core/string_utils.h"
 
@@ -21,13 +20,13 @@ bool format_io_uri(const IoURI& u, char* buf, size_t buf_size) {
         return false;
     }
 
-    buf[0] = '\0';
-
-    if (!*u.scheme) {
+    if (!u.is_valid()) {
         return false;
     }
 
-    if (!core::append_str(buf, buf_size, u.scheme)) {
+    buf[0] = '\0';
+
+    if (!core::append_str(buf, buf_size, u.scheme())) {
         return false;
     }
 
@@ -41,14 +40,9 @@ bool format_io_uri(const IoURI& u, char* buf, size_t buf_size) {
         }
     }
 
-    if (!*u.path) {
-        return false;
-    }
-
     const size_t pos = strlen(buf);
 
-    if (pct_encode(buf + pos, buf_size - pos, u.path, strlen(u.path), PctNonPath)
-        == -1) {
+    if (!u.get_encoded_path(buf + pos, buf_size - pos)) {
         return false;
     }
 

--- a/src/modules/roc_address/io_uri_parse.rl
+++ b/src/modules/roc_address/io_uri_parse.rl
@@ -61,10 +61,12 @@ bool parse_io_uri(const char* str, IoURI& result) {
             }
         }
 
+        pchar = [^?#];
+
         file_scheme = 'file' %set_file_scheme;
 
-        abs_path = ('/' [^/] any*) >start_token %set_path;
-        rel_path = ([^/] any*) >start_token %set_path;
+        abs_path = ('/' (pchar - '/') pchar*) >start_token %set_path;
+        rel_path = ([^/] pchar*) >start_token %set_path;
         special_path = '-' >start_token %set_path;
 
         file_hier_part = ('//' 'localhost'?)? abs_path
@@ -74,7 +76,7 @@ bool parse_io_uri(const char* str, IoURI& result) {
         file_uri = file_scheme ':' file_hier_part;
 
         device_scheme = (alnum+ - file_scheme) >start_token %set_scheme;
-        device_hier_part = any+ >start_token %set_path;
+        device_hier_part = pchar+ >start_token %set_path;
 
         device_uri = device_scheme '://' device_hier_part;
 

--- a/src/modules/roc_address/io_uri_parse.rl
+++ b/src/modules/roc_address/io_uri_parse.rl
@@ -7,10 +7,8 @@
  */
 
 #include "roc_address/io_uri.h"
-#include "roc_address/pct.h"
 #include "roc_core/log.h"
 #include "roc_core/panic.h"
-#include "roc_core/string_utils.h"
 
 namespace roc {
 namespace address {
@@ -42,21 +40,19 @@ bool parse_io_uri(const char* str, IoURI& result) {
         }
 
         action set_scheme {
-            if (!core::copy_str(result.scheme, sizeof(result.scheme), start_p, p)) {
-                roc_log(LogError, "parse io uri: too long scheme");
+            if (!result.set_scheme(start_p, p - start_p)) {
+                roc_log(LogError, "parse io uri: invalid scheme");
                 return false;
             }
         }
 
         action set_file_scheme {
-            strcpy(result.scheme, "file");
+            result.set_scheme("file", 4);
         }
 
         action set_path {
-            if (pct_decode(result.path, sizeof(result.path), start_p, p - start_p)
-                == -1) {
-                roc_log(LogError,
-                        "parse io uri: invalid percent-encoded or too long path");
+            if (!result.set_encoded_path(start_p, p - start_p)) {
+                roc_log(LogError, "parse io uri: invalid path");
                 return false;
             }
         }

--- a/src/modules/roc_address/io_uri_parse.rl
+++ b/src/modules/roc_address/io_uri_parse.rl
@@ -21,6 +21,8 @@ namespace address {
 bool parse_io_uri(const char* str, IoURI& result) {
     roc_panic_if(str == NULL);
 
+    result.clear();
+
     // for ragel
     const char* p = str;
     const char *pe = str + strlen(str);
@@ -47,7 +49,12 @@ bool parse_io_uri(const char* str, IoURI& result) {
         }
 
         action set_file_scheme {
-            result.set_scheme("file", 4);
+            const char* scheme = "file";
+
+            if (!result.set_scheme(scheme, strlen(scheme))) {
+                roc_log(LogError, "parse io uri: invalid scheme");
+                return false;
+            }
         }
 
         action set_path {

--- a/src/modules/roc_address/io_uri_to_str.cpp
+++ b/src/modules/roc_address/io_uri_to_str.cpp
@@ -13,7 +13,7 @@ namespace address {
 
 io_uri_to_str::io_uri_to_str(const IoURI& u) {
     if (!format_io_uri(u, buf_, sizeof(buf_))) {
-        strcpy(buf_, "<too long>");
+        strcpy(buf_, "<bad>");
     }
 }
 

--- a/src/modules/roc_address/io_uri_to_str.h
+++ b/src/modules/roc_address/io_uri_to_str.h
@@ -30,7 +30,7 @@ public:
     }
 
 private:
-    char buf_[IoURI::MaxLength];
+    char buf_[512];
 };
 
 } // namespace address

--- a/src/modules/roc_address/io_uri_to_str.h
+++ b/src/modules/roc_address/io_uri_to_str.h
@@ -30,7 +30,7 @@ public:
     }
 
 private:
-    char buf_[512];
+    char buf_[1024];
 };
 
 } // namespace address

--- a/src/modules/roc_sndio/backend_dispatcher.cpp
+++ b/src/modules/roc_sndio/backend_dispatcher.cpp
@@ -41,9 +41,9 @@ const char* select_driver_name(const address::IoURI& uri, const char* force_form
         return NULL;
     }
 
-    if (!uri.is_empty()) {
-        // use spcific device driver
-        return uri.scheme;
+    if (uri.is_valid()) {
+        // use specific device driver
+        return uri.scheme();
     }
 
     // use default device driver
@@ -51,10 +51,10 @@ const char* select_driver_name(const address::IoURI& uri, const char* force_form
 }
 
 const char* select_input_output(const address::IoURI& uri) {
-    if (uri.is_empty()) {
-        return NULL;
+    if (uri.is_valid()) {
+        return uri.path();
     } else {
-        return uri.path;
+        return NULL;
     }
 }
 

--- a/src/tests/roc_address/test_io_uri.cpp
+++ b/src/tests/roc_address/test_io_uri.cpp
@@ -19,12 +19,12 @@ TEST_GROUP(io_uri) {};
 TEST(io_uri, empty) {
     IoURI u;
 
-    CHECK(u.is_empty());
+    CHECK(!u.is_valid());
     CHECK(!u.is_file());
     CHECK(!u.is_special_file());
 
-    STRCMP_EQUAL("", u.scheme);
-    STRCMP_EQUAL("", u.path);
+    STRCMP_EQUAL("", u.scheme());
+    STRCMP_EQUAL("", u.path());
 
     STRCMP_EQUAL("<bad>", io_uri_to_str(u).c_str());
 }
@@ -33,12 +33,12 @@ TEST(io_uri, device) {
     IoURI u;
     CHECK(parse_io_uri("alsa://card0/subcard1", u));
 
-    CHECK(!u.is_empty());
+    CHECK(u.is_valid());
     CHECK(!u.is_file());
     CHECK(!u.is_special_file());
 
-    STRCMP_EQUAL("alsa", u.scheme);
-    STRCMP_EQUAL("card0/subcard1", u.path);
+    STRCMP_EQUAL("alsa", u.scheme());
+    STRCMP_EQUAL("card0/subcard1", u.path());
 
     STRCMP_EQUAL("alsa://card0/subcard1", io_uri_to_str(u).c_str());
 }
@@ -47,12 +47,12 @@ TEST(io_uri, file_localhost_abspath) {
     IoURI u;
     CHECK(parse_io_uri("file://localhost/home/user/test.mp3", u));
 
-    CHECK(!u.is_empty());
+    CHECK(u.is_valid());
     CHECK(u.is_file());
     CHECK(!u.is_special_file());
 
-    STRCMP_EQUAL("file", u.scheme);
-    STRCMP_EQUAL("/home/user/test.mp3", u.path);
+    STRCMP_EQUAL("file", u.scheme());
+    STRCMP_EQUAL("/home/user/test.mp3", u.path());
 
     STRCMP_EQUAL("file:/home/user/test.mp3", io_uri_to_str(u).c_str());
 }
@@ -61,12 +61,12 @@ TEST(io_uri, file_emptyhost_abspath) {
     IoURI u;
     CHECK(parse_io_uri("file:///home/user/test.mp3", u));
 
-    CHECK(!u.is_empty());
+    CHECK(u.is_valid());
     CHECK(u.is_file());
     CHECK(!u.is_special_file());
 
-    STRCMP_EQUAL("file", u.scheme);
-    STRCMP_EQUAL("/home/user/test.mp3", u.path);
+    STRCMP_EQUAL("file", u.scheme());
+    STRCMP_EQUAL("/home/user/test.mp3", u.path());
 
     STRCMP_EQUAL("file:/home/user/test.mp3", io_uri_to_str(u).c_str());
 }
@@ -75,12 +75,12 @@ TEST(io_uri, file_emptyhost_specialpath) {
     IoURI u;
     CHECK(parse_io_uri("file://-", u));
 
-    CHECK(!u.is_empty());
+    CHECK(u.is_valid());
     CHECK(u.is_file());
     CHECK(u.is_special_file());
 
-    STRCMP_EQUAL("file", u.scheme);
-    STRCMP_EQUAL("-", u.path);
+    STRCMP_EQUAL("file", u.scheme());
+    STRCMP_EQUAL("-", u.path());
 
     STRCMP_EQUAL("file:-", io_uri_to_str(u).c_str());
 }
@@ -89,12 +89,12 @@ TEST(io_uri, file_compact_abspath) {
     IoURI u;
     CHECK(parse_io_uri("file:/home/user/test.mp3", u));
 
-    CHECK(!u.is_empty());
+    CHECK(u.is_valid());
     CHECK(u.is_file());
     CHECK(!u.is_special_file());
 
-    STRCMP_EQUAL("file", u.scheme);
-    STRCMP_EQUAL("/home/user/test.mp3", u.path);
+    STRCMP_EQUAL("file", u.scheme());
+    STRCMP_EQUAL("/home/user/test.mp3", u.path());
 
     STRCMP_EQUAL("file:/home/user/test.mp3", io_uri_to_str(u).c_str());
 }
@@ -103,12 +103,12 @@ TEST(io_uri, file_compact_relpath1) {
     IoURI u;
     CHECK(parse_io_uri("file:./test.mp3", u));
 
-    CHECK(!u.is_empty());
+    CHECK(u.is_valid());
     CHECK(u.is_file());
     CHECK(!u.is_special_file());
 
-    STRCMP_EQUAL("file", u.scheme);
-    STRCMP_EQUAL("./test.mp3", u.path);
+    STRCMP_EQUAL("file", u.scheme());
+    STRCMP_EQUAL("./test.mp3", u.path());
 
     STRCMP_EQUAL("file:./test.mp3", io_uri_to_str(u).c_str());
 }
@@ -117,12 +117,12 @@ TEST(io_uri, file_compact_relpath2) {
     IoURI u;
     CHECK(parse_io_uri("file:test/test.mp3", u));
 
-    CHECK(!u.is_empty());
+    CHECK(u.is_valid());
     CHECK(u.is_file());
     CHECK(!u.is_special_file());
 
-    STRCMP_EQUAL("file", u.scheme);
-    STRCMP_EQUAL("test/test.mp3", u.path);
+    STRCMP_EQUAL("file", u.scheme());
+    STRCMP_EQUAL("test/test.mp3", u.path());
 
     STRCMP_EQUAL("file:test/test.mp3", io_uri_to_str(u).c_str());
 }
@@ -131,12 +131,12 @@ TEST(io_uri, file_compact_specialpath) {
     IoURI u;
     CHECK(parse_io_uri("file:-", u));
 
-    CHECK(!u.is_empty());
+    CHECK(u.is_valid());
     CHECK(u.is_file());
     CHECK(u.is_special_file());
 
-    STRCMP_EQUAL("file", u.scheme);
-    STRCMP_EQUAL("-", u.path);
+    STRCMP_EQUAL("file", u.scheme());
+    STRCMP_EQUAL("-", u.path());
 
     STRCMP_EQUAL("file:-", io_uri_to_str(u).c_str());
 }
@@ -146,8 +146,8 @@ TEST(io_uri, percent_encoding) {
         IoURI u;
         CHECK(parse_io_uri("alsa://foo%21/bar!%2Fbaz%23", u));
 
-        STRCMP_EQUAL("alsa", u.scheme);
-        STRCMP_EQUAL("foo!/bar!/baz#", u.path);
+        STRCMP_EQUAL("alsa", u.scheme());
+        STRCMP_EQUAL("foo!/bar!/baz#", u.path());
 
         STRCMP_EQUAL("alsa://foo!/bar!/baz%23", io_uri_to_str(u).c_str());
     }
@@ -156,8 +156,8 @@ TEST(io_uri, percent_encoding) {
         IoURI u;
         CHECK(parse_io_uri("file:///foo%21/bar!%2Fbaz%23", u));
 
-        STRCMP_EQUAL("file", u.scheme);
-        STRCMP_EQUAL("/foo!/bar!/baz#", u.path);
+        STRCMP_EQUAL("file", u.scheme());
+        STRCMP_EQUAL("/foo!/bar!/baz#", u.path());
 
         STRCMP_EQUAL("file:/foo!/bar!/baz%23", io_uri_to_str(u).c_str());
     }
@@ -166,8 +166,8 @@ TEST(io_uri, percent_encoding) {
         IoURI u;
         CHECK(parse_io_uri("file:foo%21/bar!%2Fbaz%23", u));
 
-        STRCMP_EQUAL("file", u.scheme);
-        STRCMP_EQUAL("foo!/bar!/baz#", u.path);
+        STRCMP_EQUAL("file", u.scheme());
+        STRCMP_EQUAL("foo!/bar!/baz#", u.path());
 
         STRCMP_EQUAL("file:foo!/bar!/baz%23", io_uri_to_str(u).c_str());
     }

--- a/src/tests/roc_address/test_io_uri.cpp
+++ b/src/tests/roc_address/test_io_uri.cpp
@@ -144,32 +144,32 @@ TEST(io_uri, file_compact_specialpath) {
 TEST(io_uri, percent_encoding) {
     {
         IoURI u;
-        CHECK(parse_io_uri("alsa://foo%21/bar!%2Fbaz#/qux%23", u));
+        CHECK(parse_io_uri("alsa://foo%21/bar!%2Fbaz%23", u));
 
         STRCMP_EQUAL("alsa", u.scheme);
-        STRCMP_EQUAL("foo!/bar!/baz#/qux#", u.path);
+        STRCMP_EQUAL("foo!/bar!/baz#", u.path);
 
-        STRCMP_EQUAL("alsa://foo!/bar!/baz%23/qux%23", io_uri_to_str(u).c_str());
+        STRCMP_EQUAL("alsa://foo!/bar!/baz%23", io_uri_to_str(u).c_str());
     }
 
     {
         IoURI u;
-        CHECK(parse_io_uri("file:///foo%21/bar!%2Fbaz#/qux%23", u));
+        CHECK(parse_io_uri("file:///foo%21/bar!%2Fbaz%23", u));
 
         STRCMP_EQUAL("file", u.scheme);
-        STRCMP_EQUAL("/foo!/bar!/baz#/qux#", u.path);
+        STRCMP_EQUAL("/foo!/bar!/baz#", u.path);
 
-        STRCMP_EQUAL("file:/foo!/bar!/baz%23/qux%23", io_uri_to_str(u).c_str());
+        STRCMP_EQUAL("file:/foo!/bar!/baz%23", io_uri_to_str(u).c_str());
     }
 
     {
         IoURI u;
-        CHECK(parse_io_uri("file:foo%21/bar!%2Fbaz#/qux%23", u));
+        CHECK(parse_io_uri("file:foo%21/bar!%2Fbaz%23", u));
 
         STRCMP_EQUAL("file", u.scheme);
-        STRCMP_EQUAL("foo!/bar!/baz#/qux#", u.path);
+        STRCMP_EQUAL("foo!/bar!/baz#", u.path);
 
-        STRCMP_EQUAL("file:foo!/bar!/baz%23/qux%23", io_uri_to_str(u).c_str());
+        STRCMP_EQUAL("file:foo!/bar!/baz%23", io_uri_to_str(u).c_str());
     }
 }
 
@@ -232,6 +232,12 @@ TEST(io_uri, bad_syntax) {
 
     CHECK(!parse_io_uri("file://test%", u));
     CHECK(!parse_io_uri("file://test%--test", u));
+
+    CHECK(!parse_io_uri("file://test?test", u));
+    CHECK(!parse_io_uri("file://test?test#test", u));
+    CHECK(!parse_io_uri("file://test#test", u));
+    CHECK(!parse_io_uri("file://?", u));
+    CHECK(!parse_io_uri("file://#", u));
 
     CHECK(!parse_io_uri("test", u));
     CHECK(!parse_io_uri("/test", u));

--- a/src/tests/roc_address/test_io_uri.cpp
+++ b/src/tests/roc_address/test_io_uri.cpp
@@ -10,14 +10,17 @@
 
 #include "roc_address/io_uri.h"
 #include "roc_address/io_uri_to_str.h"
+#include "roc_core/heap_allocator.h"
 
 namespace roc {
 namespace address {
 
-TEST_GROUP(io_uri) {};
+TEST_GROUP(io_uri) {
+    core::HeapAllocator allocator;
+};
 
 TEST(io_uri, empty) {
-    IoURI u;
+    IoURI u(allocator);
 
     CHECK(!u.is_valid());
     CHECK(!u.is_file());
@@ -30,7 +33,7 @@ TEST(io_uri, empty) {
 }
 
 TEST(io_uri, device) {
-    IoURI u;
+    IoURI u(allocator);
     CHECK(parse_io_uri("alsa://card0/subcard1", u));
 
     CHECK(u.is_valid());
@@ -44,7 +47,7 @@ TEST(io_uri, device) {
 }
 
 TEST(io_uri, file_localhost_abspath) {
-    IoURI u;
+    IoURI u(allocator);
     CHECK(parse_io_uri("file://localhost/home/user/test.mp3", u));
 
     CHECK(u.is_valid());
@@ -58,7 +61,7 @@ TEST(io_uri, file_localhost_abspath) {
 }
 
 TEST(io_uri, file_emptyhost_abspath) {
-    IoURI u;
+    IoURI u(allocator);
     CHECK(parse_io_uri("file:///home/user/test.mp3", u));
 
     CHECK(u.is_valid());
@@ -72,7 +75,7 @@ TEST(io_uri, file_emptyhost_abspath) {
 }
 
 TEST(io_uri, file_emptyhost_specialpath) {
-    IoURI u;
+    IoURI u(allocator);
     CHECK(parse_io_uri("file://-", u));
 
     CHECK(u.is_valid());
@@ -86,7 +89,7 @@ TEST(io_uri, file_emptyhost_specialpath) {
 }
 
 TEST(io_uri, file_compact_abspath) {
-    IoURI u;
+    IoURI u(allocator);
     CHECK(parse_io_uri("file:/home/user/test.mp3", u));
 
     CHECK(u.is_valid());
@@ -100,7 +103,7 @@ TEST(io_uri, file_compact_abspath) {
 }
 
 TEST(io_uri, file_compact_relpath1) {
-    IoURI u;
+    IoURI u(allocator);
     CHECK(parse_io_uri("file:./test.mp3", u));
 
     CHECK(u.is_valid());
@@ -114,7 +117,7 @@ TEST(io_uri, file_compact_relpath1) {
 }
 
 TEST(io_uri, file_compact_relpath2) {
-    IoURI u;
+    IoURI u(allocator);
     CHECK(parse_io_uri("file:test/test.mp3", u));
 
     CHECK(u.is_valid());
@@ -128,7 +131,7 @@ TEST(io_uri, file_compact_relpath2) {
 }
 
 TEST(io_uri, file_compact_specialpath) {
-    IoURI u;
+    IoURI u(allocator);
     CHECK(parse_io_uri("file:-", u));
 
     CHECK(u.is_valid());
@@ -143,7 +146,7 @@ TEST(io_uri, file_compact_specialpath) {
 
 TEST(io_uri, percent_encoding) {
     {
-        IoURI u;
+        IoURI u(allocator);
         CHECK(parse_io_uri("alsa://foo%21/bar!%2Fbaz%23", u));
 
         STRCMP_EQUAL("alsa", u.scheme());
@@ -153,7 +156,7 @@ TEST(io_uri, percent_encoding) {
     }
 
     {
-        IoURI u;
+        IoURI u(allocator);
         CHECK(parse_io_uri("file:///foo%21/bar!%2Fbaz%23", u));
 
         STRCMP_EQUAL("file", u.scheme());
@@ -163,7 +166,7 @@ TEST(io_uri, percent_encoding) {
     }
 
     {
-        IoURI u;
+        IoURI u(allocator);
         CHECK(parse_io_uri("file:foo%21/bar!%2Fbaz%23", u));
 
         STRCMP_EQUAL("file", u.scheme());
@@ -174,7 +177,7 @@ TEST(io_uri, percent_encoding) {
 }
 
 TEST(io_uri, small_buffer) {
-    IoURI u;
+    IoURI u(allocator);
     CHECK(parse_io_uri("abcdef://abcdef", u));
 
     char buf[16];
@@ -186,7 +189,7 @@ TEST(io_uri, small_buffer) {
 }
 
 TEST(io_uri, bad_syntax) {
-    IoURI u;
+    IoURI u(allocator);
 
     CHECK(parse_io_uri("abcdefg://test", u));
     CHECK(!parse_io_uri("abcdefghijklmnop://test", u));

--- a/src/tools/roc_conv/main.cpp
+++ b/src/tools/roc_conv/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
     source_config.sample_rate = 0;
     source_config.frame_size = config.internal_frame_size;
 
-    address::IoURI input;
+    address::IoURI input(allocator);
     if (args.input_given) {
         if (!address::parse_io_uri(args.input_arg, input) || !input.is_file()) {
             roc_log(LogError, "invalid --input file URI");
@@ -154,7 +154,7 @@ int main(int argc, char** argv) {
     sink_config.sample_rate = config.output_sample_rate;
     sink_config.frame_size = config.internal_frame_size;
 
-    address::IoURI output;
+    address::IoURI output(allocator);
     if (args.output_given) {
         if (!address::parse_io_uri(args.output_arg, output) || !output.is_file()) {
             roc_log(LogError, "invalid --output file URI");

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -230,7 +230,7 @@ int main(int argc, char** argv) {
     }
 
     if (args.format_given) {
-        if (!output.is_empty() && !output.is_file()) {
+        if (output.is_valid() && !output.is_file()) {
             roc_log(LogError, "--format can't be used if --output is not a file URI");
             return 1;
         }

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -221,7 +221,7 @@ int main(int argc, char** argv) {
         allocator, config.common.internal_frame_size, args.poisoning_flag);
     packet::PacketPool packet_pool(allocator, args.poisoning_flag);
 
-    address::IoURI output;
+    address::IoURI output(allocator);
     if (args.output_given) {
         if (!address::parse_io_uri(args.output_arg, output)) {
             roc_log(LogError, "invalid --output file or device URI");

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -212,7 +212,7 @@ int main(int argc, char** argv) {
     }
 
     if (args.format_given) {
-        if (!input.is_empty() && !input.is_file()) {
+        if (input.is_valid() && !input.is_file()) {
             roc_log(LogError, "--format can't be used if --input is not a file URI");
             return 1;
         }

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -203,7 +203,7 @@ int main(int argc, char** argv) {
         allocator, config.internal_frame_size, args.poisoning_flag);
     packet::PacketPool packet_pool(allocator, args.poisoning_flag);
 
-    address::IoURI input;
+    address::IoURI input(allocator);
     if (args.input_given) {
         if (!address::parse_io_uri(args.input_arg, input)) {
             roc_log(LogError, "invalid --input file or device URI");


### PR DESCRIPTION
I'm working on EndpointURI (#258) and also prepared several fixes for IoURI to make the two URL types consistent.

Changes:

* Don't parse query and fragment as a part of a path. Instead, fail the whole parsing if they're present. (IoURI will disallow them. EndpointURI will allow them).

* Don't allow formatting invalid URIs (e.g. without a scheme or without a path).

* Allocate memory on heap for large URI components. Don't limit components lengths. (EndpointURI will contain more components and using fixed-size arrays for them would lead to too large objects, something like a few kilobytes per URI).