### PR TITLE
Implement EndpointURI

### DIFF
--- a/src/modules/roc_address/endpoint_enums.h
+++ b/src/modules/roc_address/endpoint_enums.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_address/endpoint_enums.h
+//! @brief Network endpoint enums.
+
+#ifndef ROC_ADDRESS_ENDPOINT_ENUMS_H_
+#define ROC_ADDRESS_ENDPOINT_ENUMS_H_
+
+namespace roc {
+namespace address {
+
+//! Network endpoint type.
+enum EndpointType {
+    //! Session initiation and control.
+    EndType_Session,
+
+    //! Audio source packets.
+    EndType_AudioSource,
+
+    //! Audio repair packets.
+    EndType_AudioRepair
+};
+
+//! Network endpoint protocol.
+enum EndpointProtocol {
+    //! Protocol is not set.
+    EndProto_None,
+
+    //! RTSP.
+    EndProto_RTSP,
+
+    //! Bare RTP.
+    EndProto_RTP,
+
+    //! RTP source packet + FECFRAME Reed-Solomon footer (m=8).
+    EndProto_RTP_RS8M_Source,
+
+    //! FEC repair packet + FECFRAME Reed-Solomon header (m=8).
+    EndProto_RS8M_Repair,
+
+    //! RTP source packet + FECFRAME LDPC footer.
+    EndProto_RTP_LDPC_Source,
+
+    //! FEC repair packet + FECFRAME LDPC header.
+    EndProto_LDPC_Repair
+};
+
+} // namespace address
+} // namespace roc
+
+#endif // ROC_ADDRESS_ENDPOINT_ENUMS_H_

--- a/src/modules/roc_address/endpoint_type_to_str.cpp
+++ b/src/modules/roc_address/endpoint_type_to_str.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_address/endpoint_type_to_str.h"
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace address {
+
+const char* endpoint_type_to_str(EndpointType type) {
+    switch (type) {
+    case EndType_Session:
+        return "session";
+
+    case EndType_AudioSource:
+        return "source";
+
+    case EndType_AudioRepair:
+        return "repair";
+    }
+
+    return NULL;
+}
+
+} // namespace address
+} // namespace roc

--- a/src/modules/roc_address/endpoint_type_to_str.h
+++ b/src/modules/roc_address/endpoint_type_to_str.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_address/endpoint_type_to_str.h
+//! @brief Convert endpoint type to string.
+
+#ifndef ROC_ADDRESS_ENDPOINT_TYPE_TO_STR_H_
+#define ROC_ADDRESS_ENDPOINT_TYPE_TO_STR_H_
+
+#include "roc_address/endpoint_enums.h"
+
+namespace roc {
+namespace address {
+
+//! Convert endpoint type to string.
+const char* endpoint_type_to_str(EndpointType);
+
+} // namespace address
+} // namespace roc
+
+#endif // ROC_ADDRESS_ENDPOINT_TYPE_TO_STR_H_

--- a/src/modules/roc_address/endpoint_uri.cpp
+++ b/src/modules/roc_address/endpoint_uri.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_address/endpoint_uri.h"
+#include "roc_address/pct.h"
+#include "roc_core/string_utils.h"
+
+namespace roc {
+namespace address {
+
+EndpointURI::EndpointURI(core::IAllocator& allocator)
+    : host_(allocator)
+    , path_(allocator)
+    , query_(allocator)
+    , frag_(allocator) {
+    clear();
+}
+
+bool EndpointURI::is_valid() const {
+    return proto_ != EndProto_None && host_.size() != 0;
+}
+
+void EndpointURI::clear() {
+    proto_ = EndProto_None;
+    host_.resize(0);
+    port_ = -1;
+    path_.resize(0);
+    query_.resize(0);
+    frag_.resize(0);
+}
+
+EndpointProtocol EndpointURI::proto() const {
+    if (!is_valid()) {
+        return EndProto_None;
+    }
+    return proto_;
+}
+
+void EndpointURI::set_proto(EndpointProtocol proto) {
+    proto_ = proto;
+}
+
+const char* EndpointURI::host() const {
+    if (!is_valid()) {
+        return "";
+    }
+    return &host_[0];
+}
+
+bool EndpointURI::set_encoded_host(const char* str, size_t str_len) {
+    if (str_len < 1) {
+        return false;
+    }
+
+    const size_t buf_size = str_len + 1;
+
+    if (!host_.resize(buf_size)) {
+        return false;
+    }
+
+    if (pct_decode(&host_[0], buf_size, str, str_len) == -1) {
+        return false;
+    }
+
+    return true;
+}
+
+bool EndpointURI::get_encoded_host(char* str, size_t str_len) const {
+    if (!is_valid()) {
+        return false;
+    }
+    return pct_encode(str, str_len, &host_[0], strlen(&host_[0]), PctNonHost) != -1;
+}
+
+int EndpointURI::port() const {
+    return port_;
+}
+
+bool EndpointURI::set_port(int port) {
+    if (port < 0 || port > 65535) {
+        return false;
+    }
+
+    port_ = port;
+
+    return true;
+}
+
+const char* EndpointURI::path() const {
+    if (!is_valid() || path_.size() == 0) {
+        return NULL;
+    }
+    return &path_[0];
+}
+
+bool EndpointURI::set_encoded_path(const char* str, size_t str_len) {
+    if (str_len < 1) {
+        path_.resize(0);
+        return true;
+    }
+
+    const size_t buf_size = str_len + 1;
+
+    if (!path_.resize(buf_size)) {
+        return false;
+    }
+
+    if (pct_decode(&path_[0], buf_size, str, str_len) == -1) {
+        return false;
+    }
+
+    return true;
+}
+
+bool EndpointURI::get_encoded_path(char* str, size_t str_len) const {
+    if (!is_valid() || path_.size() == 0) {
+        return false;
+    }
+    return pct_encode(str, str_len, &path_[0], strlen(&path_[0]), PctNonPath) != -1;
+}
+
+const char* EndpointURI::encoded_query() const {
+    if (!is_valid() || query_.size() == 0) {
+        return NULL;
+    }
+    return &query_[0];
+}
+
+bool EndpointURI::set_encoded_query(const char* str, size_t str_len) {
+    if (str_len < 1) {
+        query_.resize(0);
+        return true;
+    }
+
+    const size_t buf_size = str_len + 1;
+
+    if (!query_.resize(buf_size)) {
+        return false;
+    }
+
+    if (!core::copy_str(&query_[0], buf_size, str, str + str_len)) {
+        return false;
+    }
+
+    return true;
+}
+
+const char* EndpointURI::encoded_fragment() const {
+    if (!is_valid() || frag_.size() == 0) {
+        return NULL;
+    }
+    return &frag_[0];
+}
+
+bool EndpointURI::set_encoded_fragment(const char* str, size_t str_len) {
+    if (str_len < 1) {
+        frag_.resize(0);
+        return true;
+    }
+
+    const size_t buf_size = str_len + 1;
+
+    if (!frag_.resize(buf_size)) {
+        return false;
+    }
+
+    if (!core::copy_str(&frag_[0], buf_size, str, str + str_len)) {
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace address
+} // namespace roc

--- a/src/modules/roc_address/endpoint_uri.h
+++ b/src/modules/roc_address/endpoint_uri.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_address/endpoint_uri.h
+//! @brief Network endpoint URI.
+
+#ifndef ROC_ADDRESS_ENDPOINT_URI_H_
+#define ROC_ADDRESS_ENDPOINT_URI_H_
+
+#include "roc_address/endpoint_enums.h"
+#include "roc_core/array.h"
+#include "roc_core/noncopyable.h"
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace address {
+
+//! Network endpoint URI.
+class EndpointURI : public core::NonCopyable<> {
+public:
+    //! Initialize empty URI.
+    explicit EndpointURI(core::IAllocator&);
+
+    //! Returns true if the URI has all required fields (protocol and host).
+    bool is_valid() const;
+
+    //! Clear all fields.
+    void clear();
+
+    //! Protocol ID (URI scheme).
+    EndpointProtocol proto() const;
+
+    //! Set protocol ID (URI scheme).
+    void set_proto(EndpointProtocol);
+
+    //! Hostname or IP address.
+    const char* host() const;
+
+    //! Set URI host.
+    //! String should be percent-encoded.
+    //! String should not be zero-terminated.
+    bool set_encoded_host(const char* str, size_t str_len);
+
+    //! Get URI host.
+    //! String will be percent-encoded.
+    //! String will be zero-terminated.
+    bool get_encoded_host(char* str, size_t str_len) const;
+
+    //! TCP or UDP port.
+    int port() const;
+
+    //! Set port.
+    bool set_port(int);
+
+    //! Decoded path.
+    const char* path() const;
+
+    //! Set URI path.
+    //! String should be percent-encoded.
+    //! String should not be zero-terminated.
+    bool set_encoded_path(const char* str, size_t str_len);
+
+    //! Get URI path.
+    //! String will be percent-encoded.
+    //! String will be zero-terminated.
+    bool get_encoded_path(char* str, size_t str_len) const;
+
+    //! Raw query.
+    const char* encoded_query() const;
+
+    //! Set query.
+    //! String should be percent-encoded.
+    //! String should not be zero-terminated.
+    bool set_encoded_query(const char* str, size_t str_len);
+
+    //! Raw fragment.
+    const char* encoded_fragment() const;
+
+    //! Set fragment.
+    //! String should be percent-encoded.
+    //! String should not be zero-terminated.
+    bool set_encoded_fragment(const char* str, size_t str_len);
+
+private:
+    EndpointProtocol proto_;
+    core::Array<char> host_;
+    int port_;
+    core::Array<char> path_;
+    core::Array<char> query_;
+    core::Array<char> frag_;
+};
+
+//! Parse EndpointURI from string.
+//!
+//! The URI should be in the following form:
+//!  - PROTOCOL://HOST[:PORT][/PATH][?QUERY][\#FRAGMENT]
+//!
+//! Examples:
+//!  - rtp+rs8m://localhost
+//!  - rtsp://localhost:123/path?query#frag
+//!  - rtp://127.0.0.1:123
+//!  - rtp://[::1]:123
+//!
+//! The URI syntax is defined by RFC 3986.
+//!
+//! The path, query, and fragment fields are allowed only for some protocols.
+//!
+//! The port field can be omitted if the protocol have standard port. Otherwise,
+//! the port can not be omitted.
+//!
+//! The path and host fields of the URI are percent-decoded. (But the set of allowed
+//! unencoded characters is different for path and host).
+//!
+//! The query and fragment fields of the URI are kept as is. The user is responsible
+//! to percent-decode them when necessary.
+//!
+//! This parser does not try to perform full URI validation. For example, it does not
+//! check that path contains only allowed symbols. If it can be parsed, it will be.
+bool parse_endpoint_uri(const char* str, EndpointType type, EndpointURI& result);
+
+//! Format EndpointURI to string.
+//!
+//! Formats a normalized form of the URI.
+//!
+//! The path and host parts of the URI are percent-encoded if necessary.
+//!
+//! The query and fragment parts are stored in the encoded form, so they
+//! ar just copied as is.
+//!
+//! @returns
+//!  true on success or false if the buffer is too small.
+bool format_endpoint_uri(const EndpointURI& uri, char* buf, size_t buf_size);
+
+//! Check if the endpoint URI is correct.
+bool validate_endpoint_uri(EndpointType type, const EndpointURI& uri);
+
+} // namespace address
+} // namespace roc
+
+#endif // ROC_ADDRESS_ENDPOINT_URI_H_

--- a/src/modules/roc_address/endpoint_uri_format.cpp
+++ b/src/modules/roc_address/endpoint_uri_format.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_address/endpoint_uri.h"
+#include "roc_address/proto.h"
+#include "roc_core/panic.h"
+#include "roc_core/string_utils.h"
+
+namespace roc {
+namespace address {
+
+bool format_endpoint_uri(const EndpointURI& u, char* buf, size_t buf_size) {
+    roc_panic_if(buf == NULL);
+
+    if (buf_size == 0) {
+        return false;
+    }
+
+    if (!u.is_valid()) {
+        return false;
+    }
+
+    buf[0] = '\0';
+
+    const char* proto = proto_to_str(u.proto());
+    if (!proto) {
+        return false;
+    }
+
+    if (!core::append_str(buf, buf_size, proto)) {
+        return false;
+    }
+
+    if (!core::append_str(buf, buf_size, "://")) {
+        return false;
+    }
+
+    size_t pos = strlen(buf);
+
+    if (!u.get_encoded_host(buf + pos, buf_size - pos)) {
+        return false;
+    }
+
+    if (u.port() > 0) {
+        if (!core::append_str(buf, buf_size, ":")) {
+            return false;
+        }
+        if (!core::append_uint(buf, buf_size, (uint64_t)u.port(), 10)) {
+            return false;
+        }
+    }
+
+    if (u.path()) {
+        pos = strlen(buf);
+
+        if (!u.get_encoded_path(buf + pos, buf_size - pos)) {
+            return false;
+        }
+    }
+
+    if (u.encoded_query()) {
+        if (!core::append_str(buf, buf_size, "?")) {
+            return false;
+        }
+        if (!core::append_str(buf, buf_size, u.encoded_query())) {
+            return false;
+        }
+    }
+
+    if (u.encoded_fragment()) {
+        if (!core::append_str(buf, buf_size, "#")) {
+            return false;
+        }
+        if (!core::append_str(buf, buf_size, u.encoded_fragment())) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace address
+} // namespace roc

--- a/src/modules/roc_address/endpoint_uri_parse.rl
+++ b/src/modules/roc_address/endpoint_uri_parse.rl
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_address/endpoint_uri.h"
+#include "roc_core/log.h"
+#include "roc_core/panic.h"
+
+namespace roc {
+namespace address {
+
+%%{
+    machine parse_endpoint_uri;
+    write data;
+}%%
+
+bool parse_endpoint_uri(const char* str,
+                        EndpointType endpoint_type,
+                        EndpointURI& result) {
+    roc_panic_if(str == NULL);
+
+    result.clear();
+
+    // for ragel
+    const char* p = str;
+    const char *pe = str + strlen(str);
+
+    const char *eof = pe;
+    int cs = 0;
+
+    // for start_token
+    const char* start_p = NULL;
+
+    // parse result
+    bool success = false;
+
+    %%{
+        action start_token {
+            start_p = p;
+        }
+
+        action set_host {
+            if (!result.set_encoded_host(start_p, p - start_p)) {
+                roc_log(LogError, "parse endpoint uri: invalid host");
+                return false;
+            }
+        }
+
+        action set_port {
+            char* end_p = NULL;
+            long port = strtol(start_p, &end_p, 10);
+
+            if (port == LONG_MAX || port == LONG_MIN || end_p != p) {
+                roc_log(LogError, "parse endpoint uri: invalid port");
+                return false;
+            }
+
+            if (!result.set_port((int)port)) {
+                roc_log(LogError, "parse endpoint uri: invalid port");
+                return false;
+            }
+        }
+
+        action set_path {
+            if (!result.set_encoded_path(start_p, p - start_p)) {
+                roc_log(LogError, "parse endpoint uri: invalid path");
+                return false;
+            }
+        }
+
+        action set_query {
+            if (!result.set_encoded_query(start_p, p - start_p)) {
+                roc_log(LogError, "parse endpoint uri: invalid query");
+                return false;
+            }
+        }
+
+        action set_fragment {
+            if (!result.set_encoded_fragment(start_p, p - start_p)) {
+                roc_log(LogError, "parse endpoint uri: invalid fragment");
+                return false;
+            }
+        }
+
+        scheme = 'rtsp'      %{ result.set_proto(EndProto_RTSP); }
+               | 'rtp'       %{ result.set_proto(EndProto_RTP); }
+               | 'rtp+rs8m'  %{ result.set_proto(EndProto_RTP_RS8M_Source); }
+               | 'rs8m'      %{ result.set_proto(EndProto_RS8M_Repair); }
+               | 'rtp+ldpc'  %{ result.set_proto(EndProto_RTP_LDPC_Source); }
+               | 'ldpc'      %{ result.set_proto(EndProto_LDPC_Repair); }
+               ;
+
+        host = ([^/:@]+) >start_token %set_host;
+        port = (digit+) >start_token %set_port;
+
+        pchar = [^?#];
+
+        path = ('/' pchar*) >start_token %set_path;
+        query = (pchar*) >start_token %set_query;
+        fragment = (pchar*) >start_token %set_fragment;
+
+        uri = scheme '://' host (':' port)? path? ('?' query)? ('#' fragment)?;
+
+        main := uri
+                %{ success = true; }
+                ;
+
+        write init;
+        write exec;
+    }%%
+
+    if (!success) {
+        roc_log(LogError,
+                "parse endpoint uri: expected"
+                " 'PROTO://HOST[:PORT][/PATH][?QUERY][#FRAGMENT]',\n"
+                " got '%s'",
+                str);
+        result.clear();
+        return false;
+    }
+
+    if (!validate_endpoint_uri(endpoint_type, result)) {
+        result.clear();
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace address
+} // namespace roc

--- a/src/modules/roc_address/endpoint_uri_to_str.cpp
+++ b/src/modules/roc_address/endpoint_uri_to_str.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_address/endpoint_uri_to_str.h"
+
+namespace roc {
+namespace address {
+
+endpoint_uri_to_str::endpoint_uri_to_str(const EndpointURI& u) {
+    if (!format_endpoint_uri(u, buf_, sizeof(buf_))) {
+        strcpy(buf_, "<bad>");
+    }
+}
+
+} // namespace address
+} // namespace roc

--- a/src/modules/roc_address/endpoint_uri_to_str.h
+++ b/src/modules/roc_address/endpoint_uri_to_str.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_address/endpoint_uri_to_str.h
+//! @brief Format EndpointURI to string.
+
+#ifndef ROC_ADDRESS_ENDPOINT_URI_TO_STR_H_
+#define ROC_ADDRESS_ENDPOINT_URI_TO_STR_H_
+
+#include "roc_address/endpoint_uri.h"
+#include "roc_core/noncopyable.h"
+
+namespace roc {
+namespace address {
+
+//! Convert EndpointURI to string.
+class endpoint_uri_to_str : public core::NonCopyable<> {
+public:
+    //! Construct.
+    explicit endpoint_uri_to_str(const EndpointURI&);
+
+    //! Get formatted string.
+    const char* c_str() const {
+        return buf_;
+    }
+
+private:
+    char buf_[1024];
+};
+
+} // namespace address
+} // namespace roc
+
+#endif // ROC_ADDRESS_ENDPOINT_URI_TO_STR_H_

--- a/src/modules/roc_address/endpoint_uri_validate.cpp
+++ b/src/modules/roc_address/endpoint_uri_validate.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_address/endpoint_type_to_str.h"
+#include "roc_address/endpoint_uri.h"
+#include "roc_address/proto.h"
+
+namespace roc {
+namespace address {
+
+namespace {
+
+bool check_protocol_type(EndpointType type, EndpointProtocol proto) {
+    switch (type) {
+    case EndType_Session:
+        switch ((int)proto) {
+        case EndProto_RTSP:
+            return true;
+        default:
+            break;
+        }
+        return false;
+
+    case EndType_AudioSource:
+        switch ((int)proto) {
+        case EndProto_RTP:
+        case EndProto_RTP_RS8M_Source:
+        case EndProto_RTP_LDPC_Source:
+            return true;
+        default:
+            break;
+        }
+        return false;
+
+    case EndType_AudioRepair:
+        switch ((int)proto) {
+        case EndProto_RS8M_Repair:
+        case EndProto_LDPC_Repair:
+            return true;
+        default:
+            break;
+        }
+        return false;
+    }
+
+    return false;
+}
+
+} // namespace
+
+bool validate_endpoint_uri(EndpointType type, const EndpointURI& uri) {
+    if (!uri.is_valid()) {
+        roc_log(LogError, "invalid endpoint uri: missing scheme or host");
+        return false;
+    }
+
+    if (!check_protocol_type(type, uri.proto())) {
+        roc_log(LogError,
+                "invalid endpoint uri:"
+                " endpoint protocol '%s' can't be used for %s endpoints",
+                proto_to_str(uri.proto()), endpoint_type_to_str(type));
+        return false;
+    }
+
+    if (uri.port() < 0 && proto_default_port(uri.proto()) < 0) {
+        roc_log(LogError,
+                "invalid endpoint uri:"
+                " endpoint protocol '%s' requires a port to be specified explicitly,"
+                " but it is omitted in the uri",
+                proto_to_str(uri.proto()));
+        return false;
+    }
+
+    if (!proto_supports_path(uri.proto())) {
+        if (uri.path() || uri.encoded_query() || uri.encoded_fragment()) {
+            roc_log(LogError,
+                    "invalid endpoint uri:"
+                    " endpoint protocol '%s' forbids using a path, query, and fragment,"
+                    " but they are present in the uri",
+                    proto_to_str(uri.proto()));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+} // namespace address
+} // namespace roc

--- a/src/modules/roc_address/pct.h
+++ b/src/modules/roc_address/pct.h
@@ -22,6 +22,9 @@ enum PctMode {
     //! Percent-encode all symbols that are not unreserved.
     PctNonUnreserved,
 
+    //! Percent-encode all symbols that are not allowed in host.
+    PctNonHost,
+
     //! Percent-encode all symbols that are not allowed in path.
     PctNonPath
 };

--- a/src/modules/roc_address/proto.cpp
+++ b/src/modules/roc_address/proto.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_address/proto.h"
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace address {
+
+packet::FECScheme proto_fec_scheme(EndpointProtocol proto) {
+    switch ((int)proto) {
+    case EndProto_RTP:
+        return packet::FEC_None;
+
+    case EndProto_RTP_RS8M_Source:
+        return packet::FEC_ReedSolomon_M8;
+
+    case EndProto_RS8M_Repair:
+        return packet::FEC_ReedSolomon_M8;
+
+    case EndProto_RTP_LDPC_Source:
+        return packet::FEC_LDPC_Staircase;
+
+    case EndProto_LDPC_Repair:
+        return packet::FEC_LDPC_Staircase;
+    }
+
+    return packet::FEC_None;
+}
+
+int proto_default_port(EndpointProtocol proto) {
+    switch ((int)proto) {
+    case EndProto_RTSP:
+        return 554;
+
+    default:
+        break;
+    }
+
+    return -1;
+}
+
+bool proto_supports_path(EndpointProtocol proto) {
+    switch ((int)proto) {
+    case EndProto_RTSP:
+        return true;
+
+    default:
+        break;
+    }
+
+    return false;
+}
+
+const char* proto_to_str(EndpointProtocol proto) {
+    switch (proto) {
+    case EndProto_None:
+        break;
+
+    case EndProto_RTSP:
+        return "rtsp";
+
+    case EndProto_RTP:
+        return "rtp";
+
+    case EndProto_RTP_RS8M_Source:
+        return "rtp+rs8m";
+
+    case EndProto_RS8M_Repair:
+        return "rs8m";
+
+    case EndProto_RTP_LDPC_Source:
+        return "rtp+ldpc";
+
+    case EndProto_LDPC_Repair:
+        return "ldpc";
+    }
+
+    return NULL;
+}
+
+} // namespace address
+} // namespace roc

--- a/src/modules/roc_address/proto.h
+++ b/src/modules/roc_address/proto.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_address/proto.h
+//! @brief Protocol functions.
+
+#ifndef ROC_ADDRESS_PROTO_H_
+#define ROC_ADDRESS_PROTO_H_
+
+#include "roc_address/endpoint_enums.h"
+#include "roc_packet/fec.h"
+
+namespace roc {
+namespace address {
+
+//! Get FEC scheme for given protocol.
+packet::FECScheme proto_fec_scheme(EndpointProtocol proto);
+
+//! Get default port number for given protocol.
+int proto_default_port(EndpointProtocol proto);
+
+//! Check whether given protocol supports path in URI.
+bool proto_supports_path(EndpointProtocol proto);
+
+//! Get string name of the protocol.
+const char* proto_to_str(EndpointProtocol proto);
+
+} // namespace address
+} // namespace roc
+
+#endif // ROC_ADDRESS_PROTO_H_

--- a/src/tests/roc_address/test_endpoint_uri.cpp
+++ b/src/tests/roc_address/test_endpoint_uri.cpp
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <CppUTest/TestHarness.h>
+
+#include "roc_address/endpoint_uri.h"
+#include "roc_address/endpoint_uri_to_str.h"
+#include "roc_core/heap_allocator.h"
+
+namespace roc {
+namespace address {
+
+TEST_GROUP(endpoint_uri) {
+    core::HeapAllocator allocator;
+};
+
+TEST(endpoint_uri, empty) {
+    EndpointURI u(allocator);
+
+    CHECK(!u.is_valid());
+
+    LONGS_EQUAL(EndProto_None, u.proto());
+    STRCMP_EQUAL("", u.host());
+    LONGS_EQUAL(-1, u.port());
+    CHECK(!u.path());
+    CHECK(!u.encoded_query());
+    CHECK(!u.encoded_fragment());
+
+    STRCMP_EQUAL("<bad>", endpoint_uri_to_str(u).c_str());
+}
+
+TEST(endpoint_uri, fields) {
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(-1, u.port());
+        CHECK(!u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123/path", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        STRCMP_EQUAL("/path", u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123/path", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123/", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        STRCMP_EQUAL("/", u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123/", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123/path?query", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        STRCMP_EQUAL("/path", u.path());
+        STRCMP_EQUAL("query", u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123/path?query", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123/path#frag", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        STRCMP_EQUAL("/path", u.path());
+        CHECK(!u.encoded_query());
+        STRCMP_EQUAL("frag", u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123/path#frag", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123/path?query#frag", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        STRCMP_EQUAL("/path", u.path());
+        STRCMP_EQUAL("query", u.encoded_query());
+        STRCMP_EQUAL("frag", u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123/path?query#frag", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123/?#", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        STRCMP_EQUAL("/", u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123/", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123?query", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        STRCMP_EQUAL("query", u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123?query", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123#frag", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        CHECK(!u.encoded_query());
+        STRCMP_EQUAL("frag", u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123#frag", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123?query#frag", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        STRCMP_EQUAL("query", u.encoded_query());
+        STRCMP_EQUAL("frag", u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123?query#frag", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123?#", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123", endpoint_uri_to_str(u).c_str());
+    }
+}
+
+TEST(endpoint_uri, protocols) {
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtsp://host:123", EndType_Session, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTSP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtsp://host:123", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtp://host:123", EndType_AudioSource, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTP, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtp://host:123", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtp+rs8m://host:123", EndType_AudioSource, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTP_RS8M_Source, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtp+rs8m://host:123", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rs8m://host:123", EndType_AudioRepair, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RS8M_Repair, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rs8m://host:123", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("rtp+ldpc://host:123", EndType_AudioSource, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_RTP_LDPC_Source, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("rtp+ldpc://host:123", endpoint_uri_to_str(u).c_str());
+    }
+    {
+        EndpointURI u(allocator);
+        CHECK(parse_endpoint_uri("ldpc://host:123", EndType_AudioRepair, u));
+        CHECK(u.is_valid());
+
+        LONGS_EQUAL(EndProto_LDPC_Repair, u.proto());
+        STRCMP_EQUAL("host", u.host());
+        LONGS_EQUAL(123, u.port());
+        CHECK(!u.path());
+        CHECK(!u.encoded_query());
+        CHECK(!u.encoded_fragment());
+
+        STRCMP_EQUAL("ldpc://host:123", endpoint_uri_to_str(u).c_str());
+    }
+}
+
+TEST(endpoint_uri, percent_encoding) {
+    EndpointURI u(allocator);
+    CHECK(parse_endpoint_uri("rtsp://"
+                             "foo%21bar%40baz%2Fqux%3Fwee"
+                             ":123"
+                             "/foo%21bar%40baz%2Fqux%3Fwee"
+                             "?foo%21bar"
+                             "#foo%21bar",
+                             EndType_Session, u));
+    CHECK(u.is_valid());
+
+    LONGS_EQUAL(EndProto_RTSP, u.proto());
+    STRCMP_EQUAL("foo!bar@baz/qux?wee", u.host());
+    LONGS_EQUAL(123, u.port());
+    STRCMP_EQUAL("/foo!bar@baz/qux?wee", u.path());
+    STRCMP_EQUAL("foo%21bar", u.encoded_query());
+    STRCMP_EQUAL("foo%21bar", u.encoded_fragment());
+
+    STRCMP_EQUAL("rtsp://"
+                 "foo!bar%40baz%2Fqux%3Fwee"
+                 ":123"
+                 "/foo!bar@baz/qux%3Fwee"
+                 "?foo%21bar"
+                 "#foo%21bar",
+                 endpoint_uri_to_str(u).c_str());
+}
+
+TEST(endpoint_uri, endpoint_types) {
+    EndpointURI u(allocator);
+
+    CHECK(parse_endpoint_uri("rtsp://host:123", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://host:123", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtsp://host:123", EndType_AudioRepair, u));
+
+    CHECK(!parse_endpoint_uri("rtp+rs8m://host:123", EndType_Session, u));
+    CHECK(parse_endpoint_uri("rtp+rs8m://host:123", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp+rs8m://host:123", EndType_AudioRepair, u));
+
+    CHECK(!parse_endpoint_uri("rs8m://host:123", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rs8m://host:123", EndType_AudioSource, u));
+    CHECK(parse_endpoint_uri("rs8m://host:123", EndType_AudioRepair, u));
+}
+
+TEST(endpoint_uri, omit_port) {
+    EndpointURI u(allocator);
+
+    CHECK(parse_endpoint_uri("rtsp://host:123", EndType_Session, u));
+    CHECK(parse_endpoint_uri("rtsp://host", EndType_Session, u));
+
+    CHECK(parse_endpoint_uri("rtp://host:123", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp://host", EndType_AudioSource, u));
+
+    CHECK(parse_endpoint_uri("rtp+rs8m://host:123", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp+rs8m://host", EndType_AudioSource, u));
+
+    CHECK(parse_endpoint_uri("rs8m://host:123", EndType_AudioRepair, u));
+    CHECK(!parse_endpoint_uri("rs8m://host", EndType_AudioRepair, u));
+
+    CHECK(parse_endpoint_uri("rtp+ldpc://host:123", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp+ldpc://host", EndType_AudioSource, u));
+
+    CHECK(parse_endpoint_uri("ldpc://host:123", EndType_AudioRepair, u));
+    CHECK(!parse_endpoint_uri("ldpc://host", EndType_AudioRepair, u));
+}
+
+TEST(endpoint_uri, non_empty_path) {
+    EndpointURI u(allocator);
+
+    CHECK(parse_endpoint_uri("rtsp://host:123", EndType_Session, u));
+    CHECK(parse_endpoint_uri("rtsp://host:123/path", EndType_Session, u));
+    CHECK(parse_endpoint_uri("rtsp://host:123?query", EndType_Session, u));
+    CHECK(parse_endpoint_uri("rtsp://host:123#frag", EndType_Session, u));
+
+    CHECK(parse_endpoint_uri("rtp://host:123", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp://host:123/path", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp://host:123?query", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp://host:123#frag", EndType_AudioSource, u));
+
+    CHECK(parse_endpoint_uri("rtp+rs8m://host:123", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp+rs8m://host:123/path", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp+rs8m://host:123?query", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp+rs8m://host:123#frag", EndType_AudioSource, u));
+
+    CHECK(parse_endpoint_uri("rs8m://host:123", EndType_AudioRepair, u));
+    CHECK(!parse_endpoint_uri("rs8m://host:123/path", EndType_AudioRepair, u));
+    CHECK(!parse_endpoint_uri("rs8m://host:123?query", EndType_AudioRepair, u));
+    CHECK(!parse_endpoint_uri("rs8m://host:123#frag", EndType_AudioRepair, u));
+
+    CHECK(parse_endpoint_uri("rtp+ldpc://host:123", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp+ldpc://host:123/path", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp+ldpc://host:123?query", EndType_AudioSource, u));
+    CHECK(!parse_endpoint_uri("rtp+ldpc://host:123#frag", EndType_AudioSource, u));
+
+    CHECK(parse_endpoint_uri("ldpc://host:123", EndType_AudioRepair, u));
+    CHECK(!parse_endpoint_uri("ldpc://host:123/path", EndType_AudioRepair, u));
+    CHECK(!parse_endpoint_uri("ldpc://host:123?query", EndType_AudioRepair, u));
+    CHECK(!parse_endpoint_uri("ldpc://host:123#frag", EndType_AudioRepair, u));
+}
+
+TEST(endpoint_uri, small_buffer) {
+    EndpointURI u(allocator);
+    CHECK(parse_endpoint_uri("rtsp://host:123/path?query#frag", EndType_Session, u));
+
+    char buf[32];
+    CHECK(format_endpoint_uri(u, buf, sizeof(buf)));
+
+    for (size_t i = 0; i < sizeof(buf); i++) {
+        CHECK(!format_endpoint_uri(u, buf, i));
+    }
+}
+
+TEST(endpoint_uri, bad_syntax) {
+    EndpointURI u(allocator);
+
+    CHECK(parse_endpoint_uri("rtsp://host:123", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("bad://host:123", EndType_Session, u));
+
+    CHECK(!parse_endpoint_uri("host:123", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("://host:123", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://:123", EndType_Session, u));
+    CHECK(!parse_endpoint_uri(" rtsp://host:123", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtp ://host:123", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://host: 123", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://host:123 ", EndType_Session, u));
+
+    CHECK(!parse_endpoint_uri("rtsp://host:port", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://host:-1", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://host:65536", EndType_Session, u));
+
+    CHECK(!parse_endpoint_uri("rtsp://host:123path", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://host:123./path", EndType_Session, u));
+
+    CHECK(!parse_endpoint_uri("rtsp://host%:123/path", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://host%--host:123/path", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://host:123/path%", EndType_Session, u));
+    CHECK(!parse_endpoint_uri("rtsp://host:123/path%--path", EndType_Session, u));
+
+    CHECK(!parse_endpoint_uri("", EndType_Session, u));
+}
+
+} // namespace address
+} // namespace roc


### PR DESCRIPTION
See #258.

The new code for endpoints in roc_address partially duplicates existing code for ports in roc_pipeline. The new code is not used anywhere so far. When the rest code base will be migrated to endpoints, the old code for ports will be removed.

See also:

* https://en.wikipedia.org/wiki/Uniform_Resource_Identifier
* https://tools.ietf.org/html/rfc3986