### PR TITLE
Relaxing roc_lib test

### DIFF
--- a/scripts/travis/linux-runtime-checks/valgrind-debug.sh
+++ b/scripts/travis/linux-runtime-checks/valgrind-debug.sh
@@ -4,8 +4,7 @@ set -euxo pipefail
 scons -Q clean
 scons -Q --enable-werror --enable-debug --build-3rdparty=all
 
-find bin/x86_64-pc-linux-gnu -name 'roc-test-*' \
-     -not -name 'roc-test-lib' |\
+find bin/x86_64-pc-linux-gnu -name 'roc-test-*' |\
     while read t
     do
         python2 scripts/wrappers/timeout.py 300 \

--- a/scripts/travis/linux-runtime-checks/valgrind-release.sh
+++ b/scripts/travis/linux-runtime-checks/valgrind-release.sh
@@ -4,8 +4,7 @@ set -euxo pipefail
 scons -Q clean
 scons -Q --enable-werror --build-3rdparty=all
 
-find bin/x86_64-pc-linux-gnu -name 'roc-test-*' \
-     -not -name 'roc-test-lib' |\
+find bin/x86_64-pc-linux-gnu -name 'roc-test-*' |\
     while read t
     do
         python2 scripts/wrappers/timeout.py 300 \

--- a/src/modules/roc_audio/latency_monitor.cpp
+++ b/src/modules/roc_audio/latency_monitor.cpp
@@ -103,7 +103,7 @@ bool LatencyMonitor::update(packet::timestamp_t pos) {
             return false;
         }
     } else {
-        report_latency_((packet::timestamp_t)latency);
+        report_latency_(latency);
     }
 
     return true;
@@ -211,10 +211,10 @@ bool LatencyMonitor::update_resampler_(packet::timestamp_t pos,
     return true;
 }
 
-void LatencyMonitor::report_latency_(packet::timestamp_t latency) {
+void LatencyMonitor::report_latency_(packet::timestamp_diff_t latency) {
     if (rate_limiter_.allow()) {
-        roc_log(LogDebug, "latency monitor: latency=%lu target=%lu",
-                (unsigned long)latency, (unsigned long)target_latency_);
+        roc_log(LogDebug, "latency monitor: latency=%ld target=%lu",
+                (long)latency, (unsigned long)target_latency_);;
     }
 }
 

--- a/src/modules/roc_audio/latency_monitor.h
+++ b/src/modules/roc_audio/latency_monitor.h
@@ -93,7 +93,7 @@ private:
     bool init_resampler_(size_t input_sample_rate, size_t output_sample_rate);
     bool update_resampler_(packet::timestamp_t time, packet::timestamp_t latency);
 
-    void report_latency_(packet::timestamp_t latency);
+    void report_latency_(packet::timestamp_diff_t latency);
 
     const packet::SortedQueue& queue_;
     const Depacketizer& depacketizer_;


### PR DESCRIPTION
Working on issue #278 

I have several questions:

1. The samples array is not defined in `TEST_GROUP` anymore. It is defined in `Sender` with a value that increases by `sample_step_` in an infinite loop. In `Receiver` I check if the sample received is equal to a multiple (maybe ? for now i only check if it is equal to a `current value` or `current value + sample_step_`) of `sample_step_` . Is it a good idea ?

2. If the test succeeds, as the `Sender` sends infinitely a signal, the `Sender` never joins. And the test never ends. Do you have any idea how I could stop it ?

3.  What value should we put for `N` for the `Receiver` (`N` defined by: the `Receiver` should accumulate `N` non-zero samples)

Thanks!

PS: I did not handle the possible overflow yet
PS2: Does another mode than `ROC_FRAME_ENCODING_PCM_FLOAT` exists for `roc_frame_encoding` (I did not see another one in the doc) ?