### PR TITLE
Switchable resampler backends (partial)

### DIFF
--- a/src/modules/roc_audio/iresampler.cpp
+++ b/src/modules/roc_audio/iresampler.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_audio/iresampler.h"
+
+namespace roc {
+namespace audio {
+
+IResampler::~IResampler() {
+}
+
+} // namespace audio
+} // namespace roc

--- a/src/modules/roc_audio/iresampler.h
+++ b/src/modules/roc_audio/iresampler.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_audio/iresampler.h
+//! @brief Audio resampler interface.
+
+#ifndef ROC_AUDIO_IRESAMPLER_H_
+#define ROC_AUDIO_IRESAMPLER_H_
+
+#include "roc_audio/frame.h"
+#include "roc_core/noncopyable.h"
+#include "roc_core/slice.h"
+
+namespace roc {
+namespace audio {
+
+//! Audio writer interface.
+class IResampler {
+public:
+    virtual ~IResampler();
+
+    //! Check if object is successfully constructed.
+    virtual bool valid() const = 0;
+
+    //! Set new resample factor.
+    //! @remarks
+    //!  Resampling algorithm needs some window of input samples. The length of the window
+    //!  (length of sinc impulse response) is a compromise between SNR and speed. It
+    //!  depends on current resampling factor. So we choose length of input buffers to let
+    //!  it handle maximum length of input. If new scaling factor breaks equation this
+    //!  function returns false.
+    virtual bool set_scaling(float) = 0;
+
+    //! Resamples the whole output frame.
+    virtual bool resample_buff(Frame& out) = 0;
+
+    //! Push new buffer on the front of the internal FIFO, which comprisesthree window_.
+    virtual void renew_buffers(core::Slice<sample_t>& prev,
+                               core::Slice<sample_t>& cur,
+                               core::Slice<sample_t>& next) = 0;
+};
+
+} // namespace audio
+} // namespace roc
+
+#endif // ROC_AUDIO_IRESAMPLER_H_

--- a/src/modules/roc_audio/resampler_builtin.h
+++ b/src/modules/roc_audio/resampler_builtin.h
@@ -6,14 +6,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-//! @file roc_audio/resampler.h
+//! @file roc_audio/resampler_builtin.h
 //! @brief Resampler.
 
-#ifndef ROC_AUDIO_RESAMPLER_H_
-#define ROC_AUDIO_RESAMPLER_H_
+#ifndef ROC_AUDIO_RESAMPLER_BUILTIN_H_
+#define ROC_AUDIO_RESAMPLER_BUILTIN_H_
 
 #include "roc_audio/frame.h"
 #include "roc_audio/ireader.h"
+#include "roc_audio/iresampler.h"
+#include "roc_audio/resampler_config.h"
 #include "roc_audio/units.h"
 #include "roc_core/array.h"
 #include "roc_core/noncopyable.h"
@@ -24,34 +26,14 @@
 namespace roc {
 namespace audio {
 
-//! Resampler parameters.
-struct ResamplerConfig {
-    //! Sinc table precision.
-    //! @remarks
-    //!  Affects sync table size.
-    //!  Lower values give lower quality but rarer cache misses.
-    size_t window_interp;
-
-    //! Resampler internal window length.
-    //! @remarks
-    //!  Affects sync table size and number of CPU cycles.
-    //!  Lower values give lower quality but higher speed and also rarer cache misses.
-    size_t window_size;
-
-    ResamplerConfig()
-        : window_interp(128)
-        , window_size(32) {
-    }
-};
-
 //! Resamples audio stream with non-integer dynamically changing factor.
-class Resampler : public core::NonCopyable<> {
+class BuiltinResampler : public IResampler, public core::NonCopyable<> {
 public:
     //! Initialize.
-    Resampler(core::IAllocator& allocator,
-              const ResamplerConfig& config,
-              packet::channel_mask_t channels,
-              size_t frame_size);
+    BuiltinResampler(core::IAllocator& allocator,
+                     const ResamplerConfig& config,
+                     packet::channel_mask_t channels,
+                     size_t frame_size);
 
     //! Check if object is successfully constructed.
     bool valid() const;
@@ -72,6 +54,8 @@ public:
     void renew_buffers(core::Slice<sample_t>& prev,
                        core::Slice<sample_t>& cur,
                        core::Slice<sample_t>& next);
+
+    ~BuiltinResampler();
 
 private:
     typedef uint32_t fixedpoint_t;
@@ -141,4 +125,4 @@ private:
 } // namespace audio
 } // namespace roc
 
-#endif // ROC_AUDIO_RESAMPLER_H_
+#endif // ROC_AUDIO_RESAMPLER_BUILTIN_H_

--- a/src/modules/roc_audio/resampler_config.h
+++ b/src/modules/roc_audio/resampler_config.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_audio/resampler_config.h
+//! @brief Resampler.
+
+#ifndef ROC_AUDIO_RESAMPLER_CONFIG_H_
+#define ROC_AUDIO_RESAMPLER_CONFIG_H_
+
+#include "roc_core/stddefs.h"
+
+namespace roc {
+namespace audio {
+//! Resampler parameters.
+struct ResamplerConfig {
+    //! Sinc table precision.
+    //! @remarks
+    //!  Affects sync table size.
+    //!  Lower values give lower quality but rarer cache misses.
+    size_t window_interp;
+
+    //! Resampler internal window length.
+    //! @remarks
+    //!  Affects sync table size and number of CPU cycles.
+    //!  Lower values give lower quality but higher speed and also rarer cache misses.
+    size_t window_size;
+
+    ResamplerConfig()
+        : window_interp(128)
+        , window_size(32) {
+    }
+};
+
+//! Indexes the backend used for the resampling.
+enum ResamplerBackend { ResamplerBackend_Builtin = 0 };
+
+} // namespace audio
+} // namespace roc
+
+#endif // ROC_AUDIO_RESAMPLER_CONFIG_H_

--- a/src/modules/roc_audio/resampler_map.cpp
+++ b/src/modules/roc_audio/resampler_map.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "roc_audio/resampler_map.h"
+#include "roc_audio/resampler_builtin.h"
+#include "roc_audio/resampler_config.h"
+
+namespace roc {
+namespace audio {
+
+IResampler* ResamplerMap::new_resampler(ResamplerBackend resampler_backend,
+                                        core::IAllocator& allocator,
+                                        const ResamplerConfig& config,
+                                        packet::channel_mask_t channels,
+                                        size_t frame_size) {
+    if (resampler_backend != ResamplerBackend_Builtin) {
+        roc_panic(
+            "No valid resampler backend selected.. selected resampler backend is : %d",
+            resampler_backend);
+    }
+
+    core::UniquePtr<IResampler> resampler;
+    switch (resampler_backend) {
+    case ResamplerBackend_Builtin:
+        resampler.reset(new (allocator)
+                            BuiltinResampler(allocator, config, channels, frame_size),
+                        allocator);
+        break;
+    }
+
+    if (!resampler || !resampler->valid()) {
+        return NULL;
+    }
+
+    return resampler.release();
+}
+
+} // namespace audio
+} // namespace roc

--- a/src/modules/roc_audio/resampler_map.h
+++ b/src/modules/roc_audio/resampler_map.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_audio/resampler_map.h
+//! @brief Resampler Map.
+
+#ifndef ROC_AUDIO_RESAMPLER_MAP_H_
+#define ROC_AUDIO_RESAMPLER_MAP_H_
+
+#include "roc_core/stddefs.h"
+
+#include "roc_audio/iresampler.h"
+#include "roc_audio/resampler_config.h"
+#include "roc_core/iallocator.h"
+#include "roc_core/unique_ptr.h"
+#include "roc_packet/units.h"
+
+namespace roc {
+namespace audio {
+//! Factory class for IResampler objects, according to the ResamplerBackend input
+class ResamplerMap {
+public:
+    //! Method to instantiate and return a pointer to a IResampler object
+    IResampler* new_resampler(ResamplerBackend resampler_backend,
+                              core::IAllocator& allocator,
+                              const ResamplerConfig& config,
+                              packet::channel_mask_t channels,
+                              size_t frame_size);
+};
+
+} // namespace audio
+} // namespace roc
+
+#endif // ROC_AUDIO_RESAMPLER_MAP_H_

--- a/src/modules/roc_audio/resampler_profile.h
+++ b/src/modules/roc_audio/resampler_profile.h
@@ -12,7 +12,7 @@
 #ifndef ROC_AUDIO_RESAMPLER_PROFILE_H_
 #define ROC_AUDIO_RESAMPLER_PROFILE_H_
 
-#include "roc_audio/resampler.h"
+#include "roc_audio/resampler_config.h"
 
 namespace roc {
 namespace audio {

--- a/src/modules/roc_audio/resampler_reader.cpp
+++ b/src/modules/roc_audio/resampler_reader.cpp
@@ -16,12 +16,10 @@ namespace roc {
 namespace audio {
 
 ResamplerReader::ResamplerReader(IReader& reader,
+                                 IResampler& resampler,
                                  core::BufferPool<sample_t>& buffer_pool,
-                                 core::IAllocator& allocator,
-                                 const ResamplerConfig& config,
-                                 packet::channel_mask_t channels,
                                  size_t frame_size)
-    : resampler_(allocator, config, channels, frame_size)
+    : resampler_(resampler)
     , reader_(reader)
     , frame_size_(frame_size)
     , frames_empty_(true)
@@ -29,9 +27,11 @@ ResamplerReader::ResamplerReader(IReader& reader,
     if (!resampler_.valid()) {
         return;
     }
+
     if (!init_frames_(buffer_pool)) {
         return;
     }
+
     valid_ = true;
 }
 

--- a/src/modules/roc_audio/resampler_reader.h
+++ b/src/modules/roc_audio/resampler_reader.h
@@ -14,7 +14,7 @@
 
 #include "roc_audio/frame.h"
 #include "roc_audio/ireader.h"
-#include "roc_audio/resampler.h"
+#include "roc_audio/iresampler.h"
 #include "roc_audio/units.h"
 #include "roc_core/array.h"
 #include "roc_core/noncopyable.h"
@@ -34,14 +34,11 @@ public:
     //!
     //! @b Parameters
     //!  - @p reader specifies input audio stream used in read()
-    //!  - @p buffer_pool is used to allocate temporary buffers
+    //!  - @p resampler interface that hides which resampler algorithm will be used
     //!  - @p frame_size is number of samples per resampler frame per audio channel
-    //!  - @p channels is the bitmask of audio channels
     ResamplerReader(IReader& reader,
+                    IResampler& resampler,
                     core::BufferPool<sample_t>& buffer_pool,
-                    core::IAllocator& allocator,
-                    const ResamplerConfig& config,
-                    packet::channel_mask_t channels,
                     size_t frame_size);
 
     //! Check if object is successfully constructed.
@@ -65,7 +62,7 @@ private:
     bool init_frames_(core::BufferPool<sample_t>&);
     void renew_frames_();
 
-    Resampler resampler_;
+    IResampler& resampler_;
     IReader& reader_;
 
     core::Slice<sample_t> frames_[3];

--- a/src/modules/roc_audio/resampler_writer.cpp
+++ b/src/modules/roc_audio/resampler_writer.cpp
@@ -16,12 +16,10 @@ namespace roc {
 namespace audio {
 
 ResamplerWriter::ResamplerWriter(IWriter& writer,
+                                 IResampler& resampler,
                                  core::BufferPool<sample_t>& buffer_pool,
-                                 core::IAllocator& allocator,
-                                 const ResamplerConfig& config,
-                                 packet::channel_mask_t channels,
                                  size_t frame_size)
-    : resampler_(allocator, config, channels, frame_size)
+    : resampler_(resampler)
     , writer_(writer)
     , frame_pos_(0)
     , frame_size_(frame_size)

--- a/src/modules/roc_audio/resampler_writer.h
+++ b/src/modules/roc_audio/resampler_writer.h
@@ -13,8 +13,9 @@
 #define ROC_AUDIO_RESAMPLER_WRITER_H_
 
 #include "roc_audio/frame.h"
+#include "roc_audio/iresampler.h"
 #include "roc_audio/iwriter.h"
-#include "roc_audio/resampler.h"
+#include "roc_audio/resampler_config.h"
 #include "roc_audio/units.h"
 #include "roc_core/array.h"
 #include "roc_core/noncopyable.h"
@@ -34,14 +35,11 @@ public:
     //!
     //! @b Parameters
     //!  - @p writer specifies output audio stream used in write()
-    //!  - @p buffer_pool is used to allocate temporary buffers
+    //!  - @p resampler interface that hides which resampler algorithm will be used
     //!  - @p frame_size is number of samples per resampler frame per audio channel
-    //!  - @p channels is the bitmask of audio channels
     ResamplerWriter(IWriter& writer,
+                    IResampler& resampler,
                     core::BufferPool<sample_t>& buffer_pool,
-                    core::IAllocator& allocator,
-                    const ResamplerConfig& config,
-                    packet::channel_mask_t channels,
                     size_t frame_size);
 
     //! Check if object is successfully constructed.
@@ -64,7 +62,7 @@ public:
 private:
     bool init_(core::BufferPool<sample_t>&);
 
-    Resampler resampler_;
+    IResampler& resampler_;
     IWriter& writer_;
 
     core::Slice<sample_t> output_;

--- a/src/modules/roc_pipeline/config.h
+++ b/src/modules/roc_pipeline/config.h
@@ -13,7 +13,7 @@
 #define ROC_PIPELINE_CONFIG_H_
 
 #include "roc_audio/latency_monitor.h"
-#include "roc_audio/resampler.h"
+#include "roc_audio/resampler_config.h"
 #include "roc_audio/watchdog.h"
 #include "roc_core/stddefs.h"
 #include "roc_core/time.h"
@@ -70,6 +70,9 @@ struct SenderConfig {
     //! Resampler parameters.
     audio::ResamplerConfig resampler;
 
+    //! To specify which resampling backend will be used.
+    audio::ResamplerBackend resampler_backend;
+
     //! FEC writer parameters.
     fec::WriterConfig fec_writer;
 
@@ -104,7 +107,8 @@ struct SenderConfig {
     bool poisoning;
 
     SenderConfig()
-        : input_sample_rate(DefaultSampleRate)
+        : resampler_backend(audio::ResamplerBackend_Builtin)
+        , input_sample_rate(DefaultSampleRate)
         , input_channels(DefaultChannelMask)
         , internal_frame_size(DefaultInternalFrameSize)
         , packet_length(DefaultPacketLength)
@@ -147,10 +151,14 @@ struct ReceiverSessionConfig {
     //! Resampler parameters.
     audio::ResamplerConfig resampler;
 
+    //! To specify which resampling backend will be used.
+    audio::ResamplerBackend resampler_backend;
+
     ReceiverSessionConfig()
         : target_latency(DefaultLatency)
         , channels(DefaultChannelMask)
-        , payload_type(0) {
+        , payload_type(0)
+        , resampler_backend(audio::ResamplerBackend_Builtin) {
         latency_monitor.min_latency = target_latency * DefaultMinLatencyFactor;
         latency_monitor.max_latency = target_latency * DefaultMaxLatencyFactor;
     }
@@ -206,6 +214,9 @@ struct ConverterConfig {
     //! Resampler parameters.
     audio::ResamplerConfig resampler;
 
+    //! To specify which resampling backend will be used.
+    audio::ResamplerBackend resampler_backend;
+
     //! Number of samples per second per channel.
     size_t input_sample_rate;
 
@@ -228,7 +239,8 @@ struct ConverterConfig {
     bool poisoning;
 
     ConverterConfig()
-        : input_sample_rate(DefaultSampleRate)
+        : resampler_backend(audio::ResamplerBackend_Builtin)
+        , input_sample_rate(DefaultSampleRate)
         , output_sample_rate(DefaultSampleRate)
         , input_channels(DefaultChannelMask)
         , output_channels(DefaultChannelMask)

--- a/src/modules/roc_pipeline/converter.h
+++ b/src/modules/roc_pipeline/converter.h
@@ -12,9 +12,11 @@
 #ifndef ROC_PIPELINE_CONVERTER_H_
 #define ROC_PIPELINE_CONVERTER_H_
 
+#include "roc_audio/iresampler.h"
 #include "roc_audio/null_writer.h"
 #include "roc_audio/poison_writer.h"
 #include "roc_audio/profiling_writer.h"
+#include "roc_audio/resampler_map.h"
 #include "roc_audio/resampler_profile.h"
 #include "roc_audio/resampler_writer.h"
 #include "roc_core/buffer_pool.h"
@@ -50,7 +52,8 @@ private:
     audio::NullWriter null_writer_;
 
     core::UniquePtr<audio::PoisonWriter> resampler_poisoner_;
-    core::UniquePtr<audio::ResamplerWriter> resampler_;
+    core::UniquePtr<audio::ResamplerWriter> resampler_writer_;
+    core::UniquePtr<audio::IResampler> resampler_;
 
     core::UniquePtr<audio::ProfilingWriter> profiler_;
 

--- a/src/modules/roc_pipeline/receiver_session.h
+++ b/src/modules/roc_pipeline/receiver_session.h
@@ -16,6 +16,7 @@
 #include "roc_audio/depacketizer.h"
 #include "roc_audio/iframe_decoder.h"
 #include "roc_audio/ireader.h"
+#include "roc_audio/iresampler.h"
 #include "roc_audio/latency_monitor.h"
 #include "roc_audio/poison_reader.h"
 #include "roc_audio/resampler_reader.h"
@@ -104,7 +105,8 @@ private:
     core::UniquePtr<audio::Depacketizer> depacketizer_;
 
     core::UniquePtr<audio::PoisonReader> resampler_poisoner_;
-    core::UniquePtr<audio::ResamplerReader> resampler_;
+    core::UniquePtr<audio::ResamplerReader> resampler_reader;
+    core::UniquePtr<audio::IResampler> resampler_;
 
     core::UniquePtr<audio::PoisonReader> session_poisoner_;
 

--- a/src/modules/roc_pipeline/sender.cpp
+++ b/src/modules/roc_pipeline/sender.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "roc_pipeline/sender.h"
+#include "roc_audio/resampler_map.h"
 #include "roc_core/log.h"
 #include "roc_core/panic.h"
 #include "roc_pipeline/port_to_str.h"
@@ -137,18 +138,31 @@ Sender::Sender(const SenderConfig& config,
             }
             awriter = resampler_poisoner_.get();
         }
-        resampler_.reset(new (allocator) audio::ResamplerWriter(
-                             *awriter, sample_buffer_pool, allocator, config.resampler,
+
+        audio::ResamplerMap resampler_map;
+
+        resampler_.reset(resampler_map.new_resampler(
+                             config.resampler_backend, allocator, config.resampler,
                              config.input_channels, config.internal_frame_size),
                          allocator);
-        if (!resampler_ || !resampler_->valid()) {
+
+        if (!resampler_) {
             return;
         }
-        if (!resampler_->set_scaling(float(config.input_sample_rate)
-                                     / format->sample_rate)) {
+
+        resampler_writer_.reset(
+            new (allocator) audio::ResamplerWriter(
+                *awriter, *resampler_, sample_buffer_pool, config.internal_frame_size),
+            allocator);
+
+        if (!resampler_writer_ || !resampler_writer_->valid()) {
             return;
         }
-        awriter = resampler_.get();
+        if (!resampler_writer_->set_scaling(float(config.input_sample_rate)
+                                            / format->sample_rate)) {
+            return;
+        }
+        awriter = resampler_writer_.get();
     }
 
     if (config.poisoning) {

--- a/src/modules/roc_pipeline/sender.h
+++ b/src/modules/roc_pipeline/sender.h
@@ -13,8 +13,10 @@
 #define ROC_PIPELINE_SENDER_H_
 
 #include "roc_audio/iframe_encoder.h"
+#include "roc_audio/iresampler.h"
 #include "roc_audio/packetizer.h"
 #include "roc_audio/poison_writer.h"
+#include "roc_audio/resampler_map.h"
 #include "roc_audio/resampler_writer.h"
 #include "roc_core/buffer_pool.h"
 #include "roc_core/iallocator.h"
@@ -78,7 +80,8 @@ private:
     core::UniquePtr<audio::Packetizer> packetizer_;
 
     core::UniquePtr<audio::PoisonWriter> resampler_poisoner_;
-    core::UniquePtr<audio::ResamplerWriter> resampler_;
+    core::UniquePtr<audio::ResamplerWriter> resampler_writer_;
+    core::UniquePtr<audio::IResampler> resampler_;
 
     core::UniquePtr<audio::PoisonWriter> pipeline_poisoner_;
 

--- a/src/tests/roc_audio/test_resampler_backends.h
+++ b/src/tests/roc_audio/test_resampler_backends.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef ROC_AUDIO_TEST_RESAMPLER_BACKENDS_H_
+#define ROC_AUDIO_TEST_RESAMPLER_BACKENDS_H_
+
+#include "roc_audio/resampler_config.h"
+#include "roc_core/helpers.h"
+
+namespace roc {
+namespace audio {
+
+namespace {
+
+ResamplerBackend Test_resampler_backends[] = { ResamplerBackend_Builtin };
+
+const size_t Test_n_resampler_backends = ROC_ARRAY_SIZE(Test_resampler_backends);
+
+} // namespace
+
+} // namespace audio
+} // namespace roc
+
+#endif // ROC_AUDIO_TEST_RESAMPLER_BACKENDS_H_

--- a/src/tools/roc_conv/cmdline.ggo
+++ b/src/tools/roc_conv/cmdline.ggo
@@ -22,6 +22,9 @@ section "Options"
 
     option "no-resampling" - "Disable resampling" flag off
 
+    option "resampler-backend" - "Resampler backend"
+        values="builtin"default="builtin" enum optional
+
     option "resampler-profile" - "Resampler profile"
         values="low","medium","high" default="medium" enum optional
 

--- a/src/tools/roc_conv/main.cpp
+++ b/src/tools/roc_conv/main.cpp
@@ -120,6 +120,15 @@ int main(int argc, char** argv) {
         config.output_sample_rate = config.input_sample_rate;
     }
 
+    switch ((unsigned)args.resampler_backend_arg) {
+    case resampler_backend_arg_builtin:
+        config.resampler_backend = audio::ResamplerBackend_Builtin;
+        break;
+
+    default:
+        break;
+    }
+
     switch ((unsigned)args.resampler_profile_arg) {
     case resampler_profile_arg_low:
         config.resampler = audio::resampler_profile(audio::ResamplerProfile_Low);

--- a/src/tools/roc_recv/cmdline.ggo
+++ b/src/tools/roc_recv/cmdline.ggo
@@ -50,6 +50,9 @@ section "Options"
 
     option "no-resampling" - "Disable resampling" flag off
 
+    option "resampler-backend" - "Resampler backend"
+        values="builtin" default="builtin" enum optional
+
     option "resampler-profile" - "Resampler profile"
         values="low","medium","high" default="medium" enum optional
 

--- a/src/tools/roc_recv/main.cpp
+++ b/src/tools/roc_recv/main.cpp
@@ -151,6 +151,15 @@ int main(int argc, char** argv) {
 
     config.common.resampling = !args.no_resampling_flag;
 
+    switch ((unsigned)args.resampler_backend_arg) {
+    case resampler_backend_arg_builtin:
+        config.default_session.resampler_backend = audio::ResamplerBackend_Builtin;
+        break;
+
+    default:
+        break;
+    }
+
     switch ((unsigned)args.resampler_profile_arg) {
     case resampler_profile_arg_low:
         config.default_session.resampler =

--- a/src/tools/roc_send/cmdline.ggo
+++ b/src/tools/roc_send/cmdline.ggo
@@ -35,6 +35,9 @@ section "Options"
 
     option "no-resampling" - "Disable resampling" flag off
 
+    option "resampler-backend" - "Resampler backend"
+        values="builtin" default="builtin" enum optional
+
     option "resampler-profile" - "Resampler profile"
         values="low","medium","high" default="medium" enum optional
 

--- a/src/tools/roc_send/main.cpp
+++ b/src/tools/roc_send/main.cpp
@@ -145,6 +145,15 @@ int main(int argc, char** argv) {
 
     config.resampling = !args.no_resampling_flag;
 
+    switch ((unsigned)args.resampler_backend_arg) {
+    case resampler_backend_arg_builtin:
+        config.resampler_backend = audio::ResamplerBackend_Builtin;
+        break;
+
+    default:
+        break;
+    }
+
     switch ((unsigned)args.resampler_profile_arg) {
     case resampler_profile_arg_low:
         config.resampler = audio::resampler_profile(audio::ResamplerProfile_Low);


### PR DESCRIPTION
Hi. I found this project very interesting and decided to contribute some code.

This PR references https://github.com/roc-project/roc/issues/235.  With https://github.com/roc-project/roc/commit/4350117aef0999431446a989c8d11b6f6fc92ff9 we can add zita and speex resamplers more easily and with https://github.com/roc-project/roc/commit/4350117aef0999431446a989c8d11b6f6fc92ff9 we have speex available, but not implemented yet to do the resampling (gives warnings about unused variables).