### PR TITLE
Fix closing of roc_receiver's ports

### DIFF
--- a/src/lib/src/private.h
+++ b/src/lib/src/private.h
@@ -16,6 +16,7 @@
 
 #include "roc_address/socket_addr.h"
 #include "roc_audio/units.h"
+#include "roc_core/array.h"
 #include "roc_core/atomic.h"
 #include "roc_core/buffer_pool.h"
 #include "roc_core/heap_allocator.h"
@@ -90,6 +91,8 @@ struct roc_receiver {
     roc::pipeline::Receiver receiver;
 
     size_t num_channels;
+
+    roc::core::Array<roc::address::SocketAddr> addresses;
 };
 
 #endif // ROC_PRIVATE_H_

--- a/src/lib/src/receiver.cpp
+++ b/src/lib/src/receiver.cpp
@@ -100,12 +100,11 @@ int roc_receiver_bind(roc_receiver* receiver,
         return -1;
     }
 
-    if (receiver->addresses.size() == receiver->addresses.max_size()) {
-        if (!receiver->addresses.grow((receiver->addresses.size() + 1) * 2)) {
-            roc_log(LogError, "roc_receiver_bind: can't grow the addresses array");
-            return -1;
-        }
+    if (!receiver->addresses.grow_exp((receiver->addresses.size() + 1))) {
+        roc_log(LogError, "roc_receiver_bind: can't grow the addresses array");
+        return -1;
     }
+
     receiver->addresses.push_back(addr);
     roc_log(LogInfo, "roc_receiver: bound to %s",
             pipeline::port_to_str(port_config).c_str());

--- a/src/lib/src/receiver.cpp
+++ b/src/lib/src/receiver.cpp
@@ -100,7 +100,12 @@ int roc_receiver_bind(roc_receiver* receiver,
         return -1;
     }
 
-    receiver->addresses.grow(receiver->addresses.size() + 1);
+    if (receiver->addresses.size() == receiver->addresses.max_size()) {
+        if (!receiver->addresses.grow((receiver->addresses.size() + 1) * 2)) {
+            roc_log(LogError, "roc_receiver_bind: can't grow the addresses array");
+            return -1;
+        }
+    }
     receiver->addresses.push_back(addr);
     roc_log(LogInfo, "roc_receiver: bound to %s",
             pipeline::port_to_str(port_config).c_str());

--- a/src/modules/roc_core/array.h
+++ b/src/modules/roc_core/array.h
@@ -184,6 +184,26 @@ public:
         return true;
     }
 
+    //! Increase exponentially array maximum size.
+    //! @remarks
+    //!  If @p min_size is greater than the current maximum size, a larger memory
+    //!  region is allocated and the array elements are copied there.
+    //!  The size growth will follow the sequence: 0, 2, 4, 8, 16, ...
+    //! @returns
+    //!  false if the allocation failed
+    bool grow_exp(size_t min_size) {
+        if (min_size <= max_size_) {
+            return true;
+        }
+
+        size_t new_size = size_;
+        while (min_size > new_size) {
+            new_size = (new_size == 0) ? 2 : new_size * 2;
+        }
+
+        return grow(new_size);
+    }
+
 private:
     T* data_;
     size_t size_;

--- a/src/modules/roc_pipeline/receiver.cpp
+++ b/src/modules/roc_pipeline/receiver.cpp
@@ -75,16 +75,6 @@ bool Receiver::add_port(const PortConfig& config) {
     return true;
 }
 
-void Receiver::iterate_ports(void (*fn)(void*, const PortConfig&), void* arg) const {
-    core::Mutex::Lock lock(control_mutex_);
-
-    core::SharedPtr<ReceiverPort> port;
-
-    for (port = ports_.front(); port; port = ports_.nextof(*port)) {
-        fn(arg, port->config());
-    }
-}
-
 size_t Receiver::num_sessions() const {
     core::Mutex::Lock lock(control_mutex_);
 

--- a/src/modules/roc_pipeline/receiver.h
+++ b/src/modules/roc_pipeline/receiver.h
@@ -55,9 +55,6 @@ public:
     //! Add receiving port.
     bool add_port(const PortConfig& config);
 
-    //! Iterate added ports.
-    void iterate_ports(void (*fn)(void*, const PortConfig&), void* arg) const;
-
     //! Get number of alive sessions.
     size_t num_sessions() const;
 

--- a/src/tests/roc_core/test_array.cpp
+++ b/src/tests/roc_core/test_array.cpp
@@ -70,6 +70,22 @@ TEST(array, grow) {
     LONGS_EQUAL(0, Object::n_objects);
 }
 
+TEST(array, grow_exp) {
+    Array<Object> array(allocator);
+
+    CHECK(array.grow_exp(3));
+
+    LONGS_EQUAL(4, array.max_size());
+    LONGS_EQUAL(0, array.size());
+    LONGS_EQUAL(0, Object::n_objects);
+
+    CHECK(array.grow_exp(1));
+
+    LONGS_EQUAL(4, array.max_size());
+    LONGS_EQUAL(0, array.size());
+    LONGS_EQUAL(0, Object::n_objects);
+}
+
 TEST(array, resize) {
     Array<Object> array(allocator);
 


### PR DESCRIPTION
Fix issue #277 

We now use of an array in roc_receiver to keep track of the addresses / ports.
The function `iterate_ports` has been removed.