### PR TITLE
Added Thread-ID to logging

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -609,6 +609,7 @@ else:
     if platform in ['linux', 'android']:
         env.Append(ROC_TARGETS=[
             'target_posixtime',
+            'target_linux',
         ])
 
     if platform in ['linux']:

--- a/src/modules/roc_core/format_tid.h
+++ b/src/modules/roc_core/format_tid.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file roc_core/format_tid.h
+//! @brief Retrieve the current thread id.
+
+#ifndef ROC_CORE_FORMAT_TID_H_
+#define ROC_CORE_FORMAT_TID_H_
+
+namespace roc {
+namespace core {
+
+//! Retrieve and format current time.
+//
+//!
+//! @returns
+//!  if obtaining thread id was successful
+//!
+//! @note
+//!  This function should not log anything because it is used
+//!  in the logger implementation.
+bool format_tid(char* buf, size_t bufsz);
+
+} // namespace core
+} // namespace roc
+
+#endif // ROC_CORE_FORMAT_TID_H_

--- a/src/modules/roc_core/target_darwin/roc_core/format_tid.cpp
+++ b/src/modules/roc_core/target_darwin/roc_core/format_tid.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "roc_core/format_tid.h"
+
+namespace roc {
+namespace core {
+
+bool format_tid(char* buf, size_t bufsz) {
+    uint64_t tid = 0;
+    pthread_threadid_np(NULL, &tid);
+    if (snprintf(buf, bufsz, "%llu", tid) < 0)
+        return false;
+    return true;
+}
+
+} // namespace core
+} // namespace roc

--- a/src/modules/roc_core/target_darwin/roc_core/format_tid.cpp
+++ b/src/modules/roc_core/target_darwin/roc_core/format_tid.cpp
@@ -17,10 +17,9 @@ namespace core {
 
 bool format_tid(char* buf, size_t bufsz) {
     uint64_t tid = 0;
-    pthread_threadid_np(NULL, &tid);
-    if (snprintf(buf, bufsz, "%llu", tid) < 0)
-        return false;
-    return true;
+    int ret_tid = pthread_threadid_np(NULL, &tid);
+    int ret_buff = snprintf(buf, bufsz, "%llu", (unsigned long long)tid);
+    return ret_tid == 0 && ret_buff > 0 && (size_t)ret_buff < bufsz;
 }
 
 } // namespace core

--- a/src/modules/roc_core/target_linux/roc_core/format_tid.cpp
+++ b/src/modules/roc_core/target_linux/roc_core/format_tid.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Roc authors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include "roc_core/format_tid.h"
+
+namespace roc {
+namespace core {
+
+bool format_tid(char* buf, size_t bufsz) {
+    pid_t tid = (pid_t)syscall(SYS_gettid);
+    if (snprintf(buf, bufsz, "%d", tid) < 0)
+        return false;
+    return true;
+}
+
+} // namespace core
+} // namespace roc

--- a/src/modules/roc_core/target_linux/roc_core/format_tid.cpp
+++ b/src/modules/roc_core/target_linux/roc_core/format_tid.cpp
@@ -17,9 +17,8 @@ namespace core {
 
 bool format_tid(char* buf, size_t bufsz) {
     pid_t tid = (pid_t)syscall(SYS_gettid);
-    if (snprintf(buf, bufsz, "%d", tid) < 0)
-        return false;
-    return true;
+    int ret = snprintf(buf, bufsz, "%llu", (unsigned long long)tid);
+    return ret > 0 && (size_t)ret < bufsz;
 }
 
 } // namespace core

--- a/src/modules/roc_core/target_stdio/roc_core/log.cpp
+++ b/src/modules/roc_core/target_stdio/roc_core/log.cpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 
 #include "roc_core/colors.h"
+#include "roc_core/format_tid.h"
 #include "roc_core/format_time.h"
 #include "roc_core/log.h"
 
@@ -77,6 +78,11 @@ void Logger::print(const char* module, LogLevel level, const char* format, ...) 
             timestamp[0] = '\0';
         }
 
+        char tid[20] = {};
+        if (!format_tid(tid, sizeof(tid))) {
+            tid[0] = '\0';
+        }
+
         const char* level_str = "???";
         switch (level) {
         case LogNone:
@@ -103,13 +109,14 @@ void Logger::print(const char* module, LogLevel level, const char* format, ...) 
                                sizeof(colored_level_str))
                 && format_colored(level, message, colored_message,
                                   sizeof(colored_message))) {
-                fprintf(stderr, "%s [%s] %s: %s\n", timestamp, colored_level_str, module,
-                        colored_message);
+                fprintf(stderr, "%s [%s] [%s] %s: %s\n", timestamp, tid,
+                        colored_level_str, module, colored_message);
                 return;
             }
         }
 
-        fprintf(stderr, "%s [%s] %s: %s\n", timestamp, level_str, module, message);
+        fprintf(stderr, "%s [%s] [%s] %s: %s\n", timestamp, tid, level_str, module,
+                message);
     }
 }
 

--- a/src/modules/roc_core/target_stdio/roc_core/log.cpp
+++ b/src/modules/roc_core/target_stdio/roc_core/log.cpp
@@ -78,7 +78,7 @@ void Logger::print(const char* module, LogLevel level, const char* format, ...) 
             timestamp[0] = '\0';
         }
 
-        char tid[20] = {};
+        char tid[21] = {};
         if (!format_tid(tid, sizeof(tid))) {
             tid[0] = '\0';
         }


### PR DESCRIPTION
Addressed issue #290. Tried compiling for mac and it seemed that I couldn't include `#include <pthread_np.h>` in order to use `pthread_getthreadid_np()` so I had to add `#define` flags around it to check for BSD otherwise Linux wouldn't compile either. Might be doing something wrong in regards to the BSD/Mac to obtain the thread id. Also unsure if I should make the thread id's return an `int` or a `pid_t`.