### PR TITLE
Fix potential deadlock in async_close()

### DIFF
--- a/src/modules/roc_netio/target_libuv/roc_netio/basic_port.h
+++ b/src/modules/roc_netio/target_libuv/roc_netio/basic_port.h
@@ -42,7 +42,11 @@ public:
     //!
     //! @remarks
     //!  Should be called from the event loop thread.
-    virtual void async_close() = 0;
+    //!
+    //! @returns
+    //!  true if asynchronous close was initiated or false if
+    //!  the port is already closed.
+    virtual bool async_close() = 0;
 
 private:
     friend class core::RefCnt<BasicPort>;

--- a/src/modules/roc_netio/target_libuv/roc_netio/event_loop.h
+++ b/src/modules/roc_netio/target_libuv/roc_netio/event_loop.h
@@ -151,6 +151,7 @@ private:
     TaskState remove_port_(Task&);
     TaskState resolve_endpoint_address_(Task&);
 
+    void async_close_port_(BasicPort& port);
     void wait_port_closed_(const BasicPort& port);
 
     packet::PacketPool& packet_pool_;

--- a/src/modules/roc_netio/target_libuv/roc_netio/udp_receiver_port.cpp
+++ b/src/modules/roc_netio/target_libuv/roc_netio/udp_receiver_port.cpp
@@ -110,16 +110,13 @@ bool UdpReceiverPort::open() {
     return true;
 }
 
-void UdpReceiverPort::async_close() {
-    if (closed_) {
-        return; // handle_closed() was already called
+bool UdpReceiverPort::async_close() {
+    if (!handle_initialized_) {
+        return false;
     }
 
-    if (!handle_initialized_) {
-        closed_ = true;
-        close_handler_.handle_closed(*this);
-
-        return;
+    if (closed_) {
+        return false;
     }
 
     roc_log(LogInfo, "udp receiver: closing port %s",
@@ -130,7 +127,6 @@ void UdpReceiverPort::async_close() {
             roc_log(LogError, "udp receiver: uv_udp_recv_stop(): [%s] %s",
                     uv_err_name(err), uv_strerror(err));
         }
-
         recv_started_ = false;
     }
 
@@ -141,6 +137,8 @@ void UdpReceiverPort::async_close() {
     if (!uv_is_closing((uv_handle_t*)&handle_)) {
         uv_close((uv_handle_t*)&handle_, close_cb_);
     }
+
+    return true;
 }
 
 void UdpReceiverPort::close_cb_(uv_handle_t* handle) {

--- a/src/modules/roc_netio/target_libuv/roc_netio/udp_receiver_port.h
+++ b/src/modules/roc_netio/target_libuv/roc_netio/udp_receiver_port.h
@@ -50,7 +50,7 @@ public:
     virtual bool open();
 
     //! Asynchronously close receiver.
-    virtual void async_close();
+    virtual bool async_close();
 
 private:
     static void close_cb_(uv_handle_t* handle);

--- a/src/modules/roc_netio/target_libuv/roc_netio/udp_sender_port.h
+++ b/src/modules/roc_netio/target_libuv/roc_netio/udp_sender_port.h
@@ -44,7 +44,7 @@ public:
     virtual bool open();
 
     //! Asynchronously close sender.
-    virtual void async_close();
+    virtual bool async_close();
 
     //! Write packet.
     //! @remarks
@@ -57,7 +57,9 @@ private:
     static void send_cb_(uv_udp_send_t* req, int status);
 
     packet::PacketPtr read_();
-    void close_();
+
+    bool fully_closed_() const;
+    void start_closing_();
 
     ICloseHandler& close_handler_;
 


### PR DESCRIPTION
In the previois implementation, async_close() was allowed to invoke
handle_close() in place. async_close() is always called under a
mutex. handle_close() acquires the mutex too, resulting in a deadlock.

The problem didn't appear in practice because the circumstances when
handle_close() is called in place are very rare: uv_udp_init() should
fail to make it happen, or double async_close() call should happen.

In the new implementation, instead of calling handle_close() in place,
async_close() returns false instead, which means that there is no need
to wait for handle_close() call.